### PR TITLE
feat: Add Go knowledge base and fill CSS content

### DIFF
--- a/src/components/knowledge/front/css/data/flexbox.tsx
+++ b/src/components/knowledge/front/css/data/flexbox.tsx
@@ -1,5 +1,9 @@
 import { QuestionCard } from "../../../../base/knowledge_question_card";
 import { InfoCard } from "../../../../card/info_card";
+import { WarningCard } from "../../../../card/warning_card";
+import { SuccessCard } from "../../../../card/success_card";
+import { SecondaryCard } from "../../../../card/secondary_card";
+import { ExpandableCode } from "../../../../base/expandable_code";
 
 interface Props {
     id: string;
@@ -12,13 +16,323 @@ export function FrontCSSFlexbox({ id }: Props) {
                 id,
                 title: "CSS Flexbox 弹性布局",
                 category: "CSS",
-                content: "CSS Flexbox 弹性布局的使用方法和常见应用场景？",
-                tags: ["CSS", "Flexbox", "弹性布局", "布局"]
+                content: "CSS Flexbox 弹性布局的核心概念、常用属性以及实际应用场景？",
+                tags: ["CSS", "Flexbox", "弹性布局", "布局", "前端"]
             }}
         >
-            <InfoCard title="敬请期待">
-                <p>Flexbox 内容正在准备中...</p>
-            </InfoCard>
+            <div className="space-y-6">
+                <SuccessCard title="核心解答">
+                    <p>Flexbox 是一种<strong>一维布局模型</strong>，旨在为容器中的项目提供更为高效和可预测的布局方式。它使得项目可以在主轴或交叉轴上灵活地对齐、分布空间，极大地简化了复杂布局的实现，尤其在构建<strong>响应式设计</strong>方面表现出色。</p>
+                </SuccessCard>
+
+                <SecondaryCard title="容器属性 (Flex Container Properties)">
+                    <div className="space-y-4">
+                        <div>
+                            <h4 className="font-semibold"><code>display: flex</code> / <code>display: inline-flex</code></h4>
+                            <p>将元素定义为 Flex 容器。<code>flex</code> 使容器表现为块级元素，<code>inline-flex</code> 使容器表现为行内元素。</p>
+                            <ExpandableCode language="css" maxHeight={80}>
+{`.container {
+    display: flex; /* 或者 inline-flex */
+}`}
+                            </ExpandableCode>
+                        </div>
+
+                        <div>
+                            <h4 className="font-semibold"><code>flex-direction</code></h4>
+                            <p>定义主轴的方向，即项目排列的方向。</p>
+                            <ul className="list-disc pl-5">
+                                <li><code>row</code> (默认): 主轴为水平方向，起点在左端。</li>
+                                <li><code>row-reverse</code>: 主轴为水平方向，起点在右端。</li>
+                                <li><code>column</code>: 主轴为垂直方向，起点在上沿。</li>
+                                <li><code>column-reverse</code>: 主轴为垂直方向，起点在下沿。</li>
+                            </ul>
+                            <ExpandableCode language="css" maxHeight={120}>
+{`.container {
+    flex-direction: row; /* row | row-reverse | column | column-reverse */
+}`}
+                            </ExpandableCode>
+                        </div>
+
+                        <div>
+                            <h4 className="font-semibold"><code>flex-wrap</code></h4>
+                            <p>定义当项目在一条轴线上排不下时如何换行。</p>
+                            <ul className="list-disc pl-5">
+                                <li><code>nowrap</code> (默认): 不换行，项目可能会溢出容器。</li>
+                                <li><code>wrap</code>: 换行，第一行在上方。</li>
+                                <li><code>wrap-reverse</code>: 换行，第一行在下方。</li>
+                            </ul>
+                            <ExpandableCode language="css" maxHeight={100}>
+{`.container {
+    flex-wrap: nowrap; /* nowrap | wrap | wrap-reverse */
+}`}
+                            </ExpandableCode>
+                        </div>
+
+                        <div>
+                            <h4 className="font-semibold"><code>flex-flow</code></h4>
+                            <p><code>flex-direction</code> 和 <code>flex-wrap</code> 的简写形式。</p>
+                            <ExpandableCode language="css" maxHeight={80}>
+{`.container {
+    flex-flow: row nowrap; /* <flex-direction> <flex-wrap> */
+}`}
+                            </ExpandableCode>
+                        </div>
+
+                        <div>
+                            <h4 className="font-semibold"><code>justify-content</code></h4>
+                            <p>定义项目在主轴上的对齐方式。</p>
+                            <ul className="list-disc pl-5">
+                                <li><code>flex-start</code> (默认): 左对齐（或上对齐）。</li>
+                                <li><code>flex-end</code>: 右对齐（或下对齐）。</li>
+                                <li><code>center</code>: 居中对齐。</li>
+                                <li><code>space-between</code>: 两端对齐，项目之间的间隔都相等。</li>
+                                <li><code>space-around</code>: 每个项目两侧的间隔相等。项目之间的间隔比项目与边框的间隔大一倍。</li>
+                                <li><code>space-evenly</code>: 项目之间以及项目与边框之间的间隔完全相等。</li>
+                            </ul>
+                            <ExpandableCode language="css" maxHeight={120}>
+{`.container {
+    justify-content: flex-start; /* flex-start | flex-end | center | space-between | space-around | space-evenly */
+}`}
+                            </ExpandableCode>
+                        </div>
+
+                        <div>
+                            <h4 className="font-semibold"><code>align-items</code></h4>
+                            <p>定义项目在交叉轴上的对齐方式。</p>
+                            <ul className="list-disc pl-5">
+                                <li><code>stretch</code> (默认): 如果项目未设置高度或设为auto，将占满整个容器的高度。</li>
+                                <li><code>flex-start</code>: 交叉轴的起点对齐。</li>
+                                <li><code>flex-end</code>: 交叉轴的终点对齐。</li>
+                                <li><code>center</code>: 交叉轴的中点对齐。</li>
+                                <li><code>baseline</code>: 项目的第一行文字的基线对齐。</li>
+                            </ul>
+                            <ExpandableCode language="css" maxHeight={120}>
+{`.container {
+    align-items: stretch; /* stretch | flex-start | flex-end | center | baseline */
+}`}
+                            </ExpandableCode>
+                        </div>
+
+                        <div>
+                            <h4 className="font-semibold"><code>align-content</code></h4>
+                            <p>定义了多根轴线的对齐方式。如果项目只有一根轴线，该属性不起作用。</p>
+                             <ul className="list-disc pl-5">
+                                <li><code>flex-start</code>: 与交叉轴的起点对齐。</li>
+                                <li><code>flex-end</code>: 与交叉轴的终点对齐。</li>
+                                <li><code>center</code>: 与交叉轴的中点对齐。</li>
+                                <li><code>space-between</code>: 与交叉轴两端对齐，轴线之间的间隔平均分布。</li>
+                                <li><code>space-around</code>: 每根轴线两侧的间隔都相等。</li>
+                                <li><code>stretch</code> (默认): 轴线占满整个交叉轴。</li>
+                            </ul>
+                            <ExpandableCode language="css" maxHeight={120}>
+{`.container {
+    align-content: stretch; /* flex-start | flex-end | center | space-between | space-around | stretch */
+}`}
+                            </ExpandableCode>
+                        </div>
+                    </div>
+                </SecondaryCard>
+
+                <SecondaryCard title="项目属性 (Flex Item Properties)">
+                    <div className="space-y-4">
+                        <div>
+                            <h4 className="font-semibold"><code>order</code></h4>
+                            <p>定义项目的排列顺序。数值越小，排列越靠前，默认为0。</p>
+                            <ExpandableCode language="css" maxHeight={80}>
+{`.item {
+    order: 0; /* <integer> */
+}`}
+                            </ExpandableCode>
+                        </div>
+
+                        <div>
+                            <h4 className="font-semibold"><code>flex-grow</code></h4>
+                            <p>定义项目的放大比例，默认为0，即如果存在剩余空间，也不放大。</p>
+                            <ExpandableCode language="css" maxHeight={80}>
+{`.item {
+    flex-grow: 0; /* <number> */
+}`}
+                            </ExpandableCode>
+                        </div>
+
+                        <div>
+                            <h4 className="font-semibold"><code>flex-shrink</code></h4>
+                            <p>定义了项目的缩小比例，默认为1，即如果空间不足，该项目将缩小。</p>
+                            <ExpandableCode language="css" maxHeight={80}>
+{`.item {
+    flex-shrink: 1; /* <number> */
+}`}
+                            </ExpandableCode>
+                        </div>
+
+                        <div>
+                            <h4 className="font-semibold"><code>flex-basis</code></h4>
+                            <p>定义了在分配多余空间之前，项目占据的主轴空间。浏览器根据这个属性，计算主轴是否有多余空间。它的默认值为<code>auto</code>，即项目的本来大小。</p>
+                            <ExpandableCode language="css" maxHeight={80}>
+{`.item {
+    flex-basis: auto; /* <length> | auto */
+}`}
+                            </ExpandableCode>
+                        </div>
+
+                        <div>
+                            <h4 className="font-semibold"><code>flex</code></h4>
+                            <p><code>flex-grow</code>, <code>flex-shrink</code> 和 <code>flex-basis</code>的简写，默认值为<code>0 1 auto</code>。后两个属性可选。</p>
+                            <ExpandableCode language="css" maxHeight={100}>
+{`.item {
+    flex: 0 1 auto; /* <flex-grow> <flex-shrink> <flex-basis> */
+    /* common values: auto (1 1 auto), none (0 0 auto), <positive-number> (positive-number 1 0%) */
+}`}
+                            </ExpandableCode>
+                        </div>
+
+                        <div>
+                            <h4 className="font-semibold"><code>align-self</code></h4>
+                            <p>允许单个项目有与其他项目不一样的对齐方式，可覆盖<code>align-items</code>属性。默认值为<code>auto</code>，表示继承父元素的<code>align-items</code>属性，如果没有父元素，则等同于<code>stretch</code>。</p>
+                            <ExpandableCode language="css" maxHeight={100}>
+{`.item {
+    align-self: auto; /* auto | flex-start | flex-end | center | baseline | stretch */
+}`}
+                            </ExpandableCode>
+                        </div>
+                    </div>
+                </SecondaryCard>
+
+                <InfoCard title="常见用例">
+                    <div className="space-y-4">
+                        <div>
+                            <h5 className="font-semibold">1. 垂直居中</h5>
+                            <p>将一个元素在其父容器中垂直居中。</p>
+                            <ExpandableCode language="html" maxHeight={180}>
+{`<div class="parent-container-center">
+    <div class="child-item">居中内容</div>
+</div>
+
+<style>
+.parent-container-center {
+    display: flex;
+    align-items: center; /* 垂直居中 */
+    justify-content: center; /* 水平居中 (可选) */
+    height: 200px; /* 需要容器有高度 */
+    background-color: #f0f0f0;
+}
+.child-item {
+    padding: 20px;
+    background-color: #3498db;
+    color: white;
+}
+</style>`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h5 className="font-semibold">2. 等高布局</h5>
+                            <p>使同一行内的项目具有相同的高度，无论其内容多少。</p>
+                            <ExpandableCode language="html" maxHeight={200}>
+{`<div class="equal-height-container">
+    <div class="column">短内容</div>
+    <div class="column">这是比较长的内容，会使得这一列变高。</div>
+    <div class="column">中等长度内容。</div>
+</div>
+
+<style>
+.equal-height-container {
+    display: flex;
+    border: 1px solid #ccc;
+}
+.column {
+    flex: 1; /* 等分宽度 */
+    padding: 1em;
+    border-right: 1px solid #eee;
+    /* align-items: stretch (默认) 使得项目高度一致 */
+}
+.column:last-child {
+    border-right: none;
+}
+</style>`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h5 className="font-semibold">3. 导航栏</h5>
+                            <p>创建响应式的导航栏，项目可以平均分布或靠边对齐。</p>
+                            <ExpandableCode language="html" maxHeight={200}>
+{`<nav class="flex-nav">
+    <a href="#" class="nav-item logo">Logo</a>
+    <a href="#" class="nav-item">首页</a>
+    <a href="#" class="nav-item">产品</a>
+    <a href="#" class="nav-item">关于我们</a>
+    <a href="#" class="nav-item push-right">登录</a>
+</nav>
+
+<style>
+.flex-nav {
+    display: flex;
+    background-color: #333;
+    padding: 0 10px;
+    align-items: center; /* 垂直居中导航项 */
+}
+.nav-item {
+    color: white;
+    padding: 15px 20px;
+    text-decoration: none;
+}
+.nav-item:hover {
+    background-color: #555;
+}
+.logo {
+    font-weight: bold;
+    font-size: 1.2em;
+}
+.push-right {
+    margin-left: auto; /* 将此项推到最右边 */
+}
+</style>`}
+                            </ExpandableCode>
+                        </div>
+                         <div>
+                            <h5 className="font-semibold">4. 卡片布局</h5>
+                            <p>使用 Flexbox 创建灵活的卡片网格布局。</p>
+                            <ExpandableCode language="html" maxHeight={250}>
+{`<div class="card-container">
+    <div class="card">卡片1</div>
+    <div class="card">卡片2 内容多一点</div>
+    <div class="card">卡片3</div>
+    <div class="card">卡片4</div>
+    <div class="card">卡片5</div>
+</div>
+
+<style>
+.card-container {
+    display: flex;
+    flex-wrap: wrap; /* 允许卡片换行 */
+    gap: 16px; /* 项目之间的间距 */
+    padding: 16px;
+    background-color: #f9f9f9;
+}
+.card {
+    flex: 1 1 200px; /* flex-grow, flex-shrink, flex-basis (最小宽度200px) */
+    background-color: white;
+    border: 1px solid #ddd;
+    padding: 20px;
+    box-shadow: 2px 2px 5px rgba(0,0,0,0.1);
+    /* 为了美观，可以添加 min-height 或让内容决定高度 */
+}
+</style>`}
+                            </ExpandableCode>
+                        </div>
+                    </div>
+                </InfoCard>
+
+                <WarningCard title="注意事项与兼容性">
+                    <ul className="list-disc pl-5 space-y-2">
+                        <li><strong>浏览器兼容性：</strong>现代浏览器对 Flexbox 支持良好。对于非常老的浏览器 (如 IE9 及以下)，Flexbox 不被支持。IE10 和 IE11 支持旧版本的 Flexbox 规范，可能需要特定的前缀 (<code>-ms-</code>)，但主流开发已基本不考虑。</li>
+                        <li><strong><code>gap</code> 属性：</strong><code>gap</code>, <code>row-gap</code>, <code>column-gap</code> 用于控制项目之间的间距，非常方便。早期它主要用于 Grid 布局，但现在已广泛支持 Flexbox。检查目标浏览器的兼容性，如果需要支持旧版浏览器，可能仍需使用 margin。</li>
+                        <li><strong>Flex 项目的百分比高度：</strong>当 Flex 项目的父容器没有固定高度时，其百分比高度可能不会如预期工作。确保 Flex 容器自身的高度是确定的。</li>
+                        <li><strong><code>flex-basis</code> 与 <code>width</code>/<code>height</code>：</strong>当 <code>flex-direction</code> 是 <code>row</code> 时，<code>flex-basis</code> 控制宽度；当是 <code>column</code> 时，控制高度。它与 <code>width</code> 或 <code>height</code> 属性同时存在时，<code>flex-basis</code> 优先级更高。</li>
+                        <li><strong>隐式最小尺寸：</strong>Flex 项目默认不会收缩到其最小内容尺寸以下 (<code>min-width: auto</code> 或 <code>min-height: auto</code>)。有时需要设置 <code>min-width: 0</code> 或 <code>min-height: 0</code> 来允许项目完全收缩。</li>
+                        <li><strong>性能：</strong>过度复杂的 Flexbox 嵌套可能会影响渲染性能，尤其是在大型应用中。尽量保持布局结构简洁。</li>
+                    </ul>
+                </WarningCard>
+            </div>
         </QuestionCard>
     );
-} 
+}

--- a/src/components/knowledge/front/css/data/grid.tsx
+++ b/src/components/knowledge/front/css/data/grid.tsx
@@ -1,5 +1,9 @@
 import { QuestionCard } from "../../../../base/knowledge_question_card";
 import { InfoCard } from "../../../../card/info_card";
+import { WarningCard } from "../../../../card/warning_card";
+import { SuccessCard } from "../../../../card/success_card";
+import { SecondaryCard } from "../../../../card/secondary_card";
+import { ExpandableCode } from "../../../../base/expandable_code";
 
 interface Props {
     id: string;
@@ -12,13 +16,234 @@ export function FrontCSSGrid({ id }: Props) {
                 id,
                 title: "CSS Grid 网格布局",
                 category: "CSS",
-                content: "CSS Grid 网格布局的使用方法和常见应用场景？",
-                tags: ["CSS", "Grid", "网格布局", "布局"]
+                content: "CSS Grid 网格布局的核心概念、常用属性以及它与 Flexbox 的区别？",
+                tags: ["CSS", "Grid", "网格布局", "布局", "二维布局"]
             }}
         >
-            <InfoCard title="敬请期待">
-                <p>Grid 内容正在准备中...</p>
-            </InfoCard>
+            <div className="space-y-6">
+                <SuccessCard title="核心解答">
+                    <p>CSS Grid 布局是一个<strong>二维网格布局系统</strong>，能够同时处理行和列。与主要用于一维布局的 Flexbox 不同，Grid 让你能够将页面分割成主要区域，或者定义元素在二维空间中的大小、位置和对齐方式。</p>
+                    <p><strong>与 Flexbox 的关系/区别：</strong></p>
+                    <ul className="list-disc pl-5">
+                        <li><strong>维度：</strong>Grid 是二维的（行和列），Flexbox 是一维的（行或列）。</li>
+                        <li><strong>设计目的：</strong>Grid 更侧重于页面级的整体布局结构，而 Flexbox 更擅长于在组件内部或局部区域对内容进行对齐和分布。</li>
+                        <li><strong>内容优先 vs. 布局优先：</strong>Flexbox 通常是内容优先的，项目大小可以影响布局；Grid 通常是布局优先的，先定义网格结构，再将项目放入。</li>
+                        <li><strong>结合使用：</strong>两者可以很好地结合使用。例如，使用 Grid 进行页面宏观布局，然后在 Grid 的单元格内使用 Flexbox 对齐其中的元素。</li>
+                    </ul>
+                </SuccessCard>
+
+                <SecondaryCard title="核心概念 - Grid 容器属性">
+                    <div className="space-y-4">
+                        <div>
+                            <h4 className="font-semibold"><code>display: grid</code> / <code>display: inline-grid</code></h4>
+                            <p>将元素定义为 Grid 容器。<code>grid</code> 使容器表现为块级元素，<code>inline-grid</code> 使容器表现为行内元素。</p>
+                            <ExpandableCode language="css" maxHeight={80}>
+{`.container {
+    display: grid; /* 或者 inline-grid */
+}`}
+                            </ExpandableCode>
+                        </div>
+
+                        <div>
+                            <h4 className="font-semibold"><code>grid-template-columns</code> / <code>grid-template-rows</code></h4>
+                            <p>定义网格的列和行的大小和数量。可以使用各种单位：</p>
+                            <ul className="list-disc pl-5">
+                                <li>固定单位: <code>px</code>, <code>em</code></li>
+                                <li>百分比: <code>%</code> (相对于容器大小)</li>
+                                <li><code>fr</code> 单位: (fraction unit) 代表网格容器中可用空间的一等份。</li>
+                                <li><code>repeat()</code> 函数: 重复创建轨道，如 <code>repeat(3, 1fr)</code> 表示三列，每列占一份。</li>
+                                <li><code>minmax(min, max)</code>: 定义一个长度范围，表示轨道长度不能小于 min，不能大于 max。</li>
+                                <li><code>auto</code>: 由浏览器决定轨道的尺寸，基于内容大小。</li>
+                                <li><code>auto-fit</code> / <code>auto-fill</code>: 在 <code>repeat()</code> 中使用，用于创建尽可能多地适应容器的轨道。</li>
+                            </ul>
+                            <ExpandableCode language="css" maxHeight={200}>
+{`.container {
+    grid-template-columns: 100px 1fr 2fr; /* 三列：固定、1份、2份 */
+    grid-template-rows: repeat(3, minmax(100px, auto)); /* 三行：最小100px，可自动增长 */
+    /* grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); */ /* 响应式列 */
+}`}
+                            </ExpandableCode>
+                        </div>
+
+                        <div>
+                            <h4 className="font-semibold"><code>grid-template-areas</code></h4>
+                            <p>用于通过命名网格区域来定义网格结构。需要配合项目属性 <code>grid-area</code> 使用。</p>
+                            <ExpandableCode language="css" maxHeight={150}>
+{`.container {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    grid-template-rows: auto 1fr auto;
+    grid-template-areas:
+        "header header header"
+        "sidebar main main"
+        "footer footer footer";
+}
+.header { grid-area: header; }
+.sidebar { grid-area: sidebar; }
+.main { grid-area: main; }
+.footer { grid-area: footer; }`}
+                            </ExpandableCode>
+                        </div>
+
+                        <div>
+                            <h4 className="font-semibold">间距 (Gaps)</h4>
+                            <p>定义网格线之间的间距（沟槽）。</p>
+                            <ul className="list-disc pl-5">
+                                <li><code>grid-column-gap</code>: 列间距 (旧)</li>
+                                <li><code>grid-row-gap</code>: 行间距 (旧)</li>
+                                <li><code>grid-gap</code>: <code>grid-row-gap</code> 和 <code>grid-column-gap</code> 的简写 (旧)</li>
+                                <li><code>column-gap</code>: 列间距 (新标准)</li>
+                                <li><code>row-gap</code>: 行间距 (新标准)</li>
+                                <li><code>gap</code>: <code>row-gap</code> 和 <code>column-gap</code> 的简写 (新标准)</li>
+                            </ul>
+                            <ExpandableCode language="css" maxHeight={100}>
+{`.container {
+    gap: 20px 10px; /* row-gap: 20px, column-gap: 10px */
+    /* grid-gap: 20px; (旧语法，行和列间距都为20px) */
+}`}
+                            </ExpandableCode>
+                        </div>
+
+                        <div>
+                            <h4 className="font-semibold"><code>justify-items</code> / <code>align-items</code></h4>
+                            <p>定义网格项目在其单元格内的对齐方式。</p>
+                            <ul className="list-disc pl-5">
+                                <li><code>justify-items</code>: 沿行轴（内联轴）对齐。值: <code>start</code>, <code>end</code>, <code>center</code>, <code>stretch</code> (默认)。</li>
+                                <li><code>align-items</code>: 沿列轴（块轴）对齐。值: <code>start</code>, <code>end</code>, <code>center</code>, <code>stretch</code> (默认), <code>baseline</code>。</li>
+                            </ul>
+                            <ExpandableCode language="css" maxHeight={100}>
+{`.container {
+    justify-items: center;
+    align-items: stretch;
+}`}
+                            </ExpandableCode>
+                        </div>
+
+                        <div>
+                            <h4 className="font-semibold"><code>justify-content</code> / <code>align-content</code></h4>
+                            <p>当网格的总大小小于其容器时，定义网格在容器内的对齐方式。</p>
+                            <ul className="list-disc pl-5">
+                                <li><code>justify-content</code>: 沿行轴对齐网格。值: <code>start</code>, <code>end</code>, <code>center</code>, <code>space-between</code>, <code>space-around</code>, <code>space-evenly</code>, <code>stretch</code>。</li>
+                                <li><code>align-content</code>: 沿列轴对齐网格。值: <code>start</code>, <code>end</code>, <code>center</code>, <code>space-between</code>, <code>space-around</code>, <code>space-evenly</code>, <code>stretch</code>。</li>
+                            </ul>
+                            <ExpandableCode language="css" maxHeight={100}>
+{`.container {
+    /* 假设网格比容器小 */
+    justify-content: center; /* 网格在容器中水平居中 */
+    align-content: space-around; /* 网格的行在容器中垂直方向上均匀分布空间 */
+}`}
+                            </ExpandableCode>
+                        </div>
+                    </div>
+                </SecondaryCard>
+
+                <SecondaryCard title="核心概念 - Grid 项目属性">
+                    <div className="space-y-4">
+                        <div>
+                            <h4 className="font-semibold"><code>grid-column-start</code> / <code>grid-column-end</code> / <code>grid-row-start</code> / <code>grid-row-end</code></h4>
+                            <p>定义网格项目在网格中的位置和跨度，通过指定网格线编号或名称。</p>
+                            <ExpandableCode language="css" maxHeight={120}>
+{`.item-a {
+    grid-column-start: 2;
+    grid-column-end: 4; /* 跨越第2和第3列 (不包括第4条线) */
+    grid-row-start: 1;
+    grid-row-end: 3;   /* 跨越第1和第2行 */
+    /* grid-column-start: span 2; (另一种方式，从当前位置开始跨越2列) */
+}`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold"><code>grid-column</code> / <code>grid-row</code></h4>
+                            <p>分别是 <code>grid-column-start</code> / <code>grid-column-end</code> 和 <code>grid-row-start</code> / <code>grid-row-end</code> 的简写。</p>
+                            <ExpandableCode language="css" maxHeight={100}>
+{`.item-b {
+    grid-column: 1 / 3; /* 等同于 grid-column-start: 1; grid-column-end: 3; */
+    grid-row: 2 / span 2; /* 从第2行开始，跨越2行 */
+}`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold"><code>grid-area</code></h4>
+                            <p>用于给网格项目分配一个名称，以便在 <code>grid-template-areas</code> 中使用。也可以作为 <code>grid-row-start</code> / <code>grid-column-start</code> / <code>grid-row-end</code> / <code>grid-column-end</code> 的简写。</p>
+                            <ExpandableCode language="css" maxHeight={100}>
+{`/* 1. 配合 grid-template-areas */
+.item-header {
+    grid-area: header;
+}
+/* 2. 作为简写: row-start / column-start / row-end / column-end */
+.item-c {
+    grid-area: 1 / 2 / 3 / 4;
+}`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold"><code>justify-self</code> / <code>align-self</code></h4>
+                            <p>允许单个网格项目覆盖容器的 <code>justify-items</code> 和 <code>align-items</code> 设置，定义其自身在其单元格内的对齐方式。</p>
+                            <ul className="list-disc pl-5">
+                                <li><code>justify-self</code>: 沿行轴对齐。值: <code>start</code>, <code>end</code>, <code>center</code>, <code>stretch</code> (默认)。</li>
+                                <li><code>align-self</code>: 沿列轴对齐。值: <code>start</code>, <code>end</code>, <code>center</code>, <code>stretch</code> (默认), <code>baseline</code>。</li>
+                            </ul>
+                            <ExpandableCode language="css" maxHeight={100}>
+{`.item-d {
+    justify-self: end;
+    align-self: center;
+}`}
+                            </ExpandableCode>
+                        </div>
+                    </div>
+                </SecondaryCard>
+
+                <InfoCard title="Grid 与 Flexbox 结合">
+                    <p>在许多实际场景中，Grid 和 Flexbox 可以协同工作，发挥各自的优势。一个常见的模式是用 Grid 构建页面的主要布局结构（如页眉、页脚、侧边栏、主内容区），然后在这些区域内部使用 Flexbox 来对齐和分布其中的具体内容项。</p>
+                    <ExpandableCode language="html" maxHeight={250}>
+{`<div class="page-container">
+    <header class="page-header">Header</header>
+    <nav class="page-nav">
+        <!-- Flexbox for nav items -->
+        <a href="#">Home</a>
+        <a href="#">About</a>
+        <a href="#">Services</a>
+    </nav>
+    <main class="page-main">Main Content</main>
+    <footer class="page-footer">Footer</footer>
+</div>
+
+<style>
+.page-container {
+    display: grid;
+    grid-template-columns: 200px 1fr;
+    grid-template-rows: auto 1fr auto;
+    grid-template-areas:
+        "header header"
+        "nav    main"
+        "footer footer";
+    min-height: 100vh;
+    gap: 10px;
+}
+.page-header { grid-area: header; background: lightblue; padding: 1em; }
+.page-nav {
+    grid-area: nav; background: lightgreen; padding: 1em;
+    /* Flexbox for internal alignment */
+    display: flex;
+    flex-direction: column; /* Align nav items vertically */
+    gap: 10px;
+}
+.page-main { grid-area: main; background: lightyellow; padding: 1em; }
+.page-footer { grid-area: footer; background: lightpink; padding: 1em; text-align: center; }
+</style>`}
+                    </ExpandableCode>
+                </InfoCard>
+
+                <WarningCard title="注意事项与浏览器兼容性">
+                    <ul className="list-disc pl-5 space-y-2">
+                        <li><strong>浏览器兼容性：</strong>现代主流浏览器对 CSS Grid 布局支持良好（包括 Edge, Firefox, Chrome, Safari）。IE10 和 IE11 支持一个过时的、带 <code>-ms-</code> 前缀的 Grid 版本，与现代规范有很大差异，通常不建议为其做兼容。</li>
+                        <li><strong>隐式网格 (Implicit Grid):</strong> 如果放置的项目超出了通过 <code>grid-template-columns/rows</code> 定义的显式网格范围，Grid 会自动创建隐式轨道来容纳这些项目。这些隐式轨道的大小可以通过 <code>grid-auto-rows</code> 和 <code>grid-auto-columns</code> 控制。</li>
+                        <li><strong><code>fr</code> 单位与内容大小:</strong> <code>fr</code> 单位分配的是可用空间，它会优先考虑固定大小的轨道、内容大小（如果轨道为 <code>auto</code>）以及 <code>gap</code>。</li>
+                        <li><strong>Subgrid (子网格):</strong> <code>subgrid</code> 是一个较新的 Grid 特性，允许嵌套的 Grid 容器参与其父 Grid 的轨道尺寸定义。这意味着子网格的行和/或列可以对齐到外部网格的轨道。目前浏览器支持正在逐步完善中，使用前需检查兼容性 (如 caniuse.com)。</li>
+                        <li><strong>可访问性 (Accessibility):</strong> Grid 布局的强大之处在于可以将视觉顺序与 DOM 顺序分离。虽然这提供了灵活性，但也可能导致可访问性问题，因为屏幕阅读器等辅助技术通常依赖于 DOM 顺序。确保源文档结构具有逻辑性。</li>
+                    </ul>
+                </WarningCard>
+            </div>
         </QuestionCard>
     );
-} 
+}

--- a/src/components/knowledge/front/css/data/layout-basics.tsx
+++ b/src/components/knowledge/front/css/data/layout-basics.tsx
@@ -1,6 +1,5 @@
 import { QuestionCard } from "../../../../base/knowledge_question_card";
 import { InfoCard } from "../../../../card/info_card";
-import { WarningCard } from "../../../../card/warning_card";
 import { SuccessCard } from "../../../../card/success_card";
 import { SecondaryCard } from "../../../../card/secondary_card";
 import { ExpandableCode } from "../../../../base/expandable_code";

--- a/src/components/knowledge/front/css/data/layout-basics.tsx
+++ b/src/components/knowledge/front/css/data/layout-basics.tsx
@@ -1,5 +1,9 @@
 import { QuestionCard } from "../../../../base/knowledge_question_card";
 import { InfoCard } from "../../../../card/info_card";
+import { WarningCard } from "../../../../card/warning_card";
+import { SuccessCard } from "../../../../card/success_card";
+import { SecondaryCard } from "../../../../card/secondary_card";
+import { ExpandableCode } from "../../../../base/expandable_code";
 
 interface Props {
     id: string;
@@ -10,15 +14,227 @@ export function FrontCSSLayoutBasics({ id }: Props) {
         <QuestionCard
             question={{
                 id,
-                title: "CSS 布局基础",
+                title: "CSS 基础布局概念",
                 category: "CSS",
-                content: "CSS 布局的基础概念和常用方法有哪些？",
-                tags: ["CSS", "布局", "基础", "Layout"]
+                content: "CSS 中的盒模型、定位、浮动以及层叠上下文等基础布局概念是什么？",
+                tags: ["CSS", "布局", "盒模型", "定位", "浮动", "层叠上下文"]
             }}
         >
-            <InfoCard title="敬请期待">
-                <p>布局基础内容正在准备中...</p>
-            </InfoCard>
+            <div className="space-y-6">
+                <SuccessCard title="核心概要">
+                    <p>在掌握现代 CSS 布局技术如 Flexbox 和 Grid 之前，理解一些基础的布局概念至关重要。这些概念包括盒模型、元素的定位方式、浮动机制以及层叠上下文等。它们是构成 CSS 布局的基石，影响着元素在页面上的显示、大小和相互作用。</p>
+                </SuccessCard>
+
+                <SecondaryCard title="盒模型 (Box Model)">
+                    <p>CSS 盒模型描述了 HTML 元素如何被渲染成一个矩形盒子。这个盒子由四个区域组成：内容 (content)、内边距 (padding)、边框 (border) 和外边距 (margin)。</p>
+                    <div className="text-center my-4">
+                        <p className="font-mono">
+                            +-------------------------------------+<br />
+                            | Margin                              |<br />
+                            |   +-------------------------------+ |<br />
+                            |   | Border                          | |<br />
+                            |   |   +-------------------------+ | |<br />
+                            |   |   | Padding                 | | |<br />
+                            |   |   |   +-------------------+ | | |<br />
+                            |   |   |   | Content           | | | |<br />
+                            |   |   |   +-------------------+ | | |<br />
+                            |   |   +-------------------------+ | |<br />
+                            |   +-------------------------------+ |<br />
+                            +-------------------------------------+
+                        </p>
+                    </div>
+                    <ul className="list-disc pl-5 space-y-1">
+                        <li><strong>Content:</strong> 盒子的内容区域，显示文本、图片等。由 <code>width</code> 和 <code>height</code> 属性定义。</li>
+                        <li><strong>Padding:</strong> 内容区域与边框之间的空白区域。由 <code>padding-top</code>, <code>padding-right</code>, <code>padding-bottom</code>, <code>padding-left</code> 或简写属性 <code>padding</code> 控制。</li>
+                        <li><strong>Border:</strong> 包围内边距和内容的边框。由 <code>border-width</code>, <code>border-style</code>, <code>border-color</code> 或简写属性 <code>border</code> 控制。</li>
+                        <li><strong>Margin:</strong> 边框以外的空白区域，用于元素与其他元素之间的间距。由 <code>margin-top</code>, <code>margin-right</code>, <code>margin-bottom</code>, <code>margin-left</code> 或简写属性 <code>margin</code> 控制。外边距可以合并 (margin collapsing)。</li>
+                    </ul>
+                    <h4 className="font-semibold mt-3"><code>box-sizing</code></h4>
+                    <p><code>box-sizing</code> 属性定义了 <code>width</code> 和 <code>height</code> 属性如何计算元素的实际宽度和高度。</p>
+                    <ul className="list-disc pl-5">
+                        <li><code>content-box</code> (默认): <code>width</code> 和 <code>height</code> 只包括内容区域的大小。Padding 和 Border 会额外增加元素的总尺寸。</li>
+                        <li><code>border-box</code>: <code>width</code> 和 <code>height</code> 包括内容、内边距和边框。这通常使得布局更容易控制，因为元素的指定宽度/高度就是其视觉上的宽度/高度。</li>
+                    </ul>
+                    <ExpandableCode language="css" maxHeight={120}>
+{`.element {
+    width: 200px;
+    height: 100px;
+    padding: 10px;
+    border: 5px solid black;
+    margin: 15px;
+    box-sizing: border-box; /* 推荐的做法 */
+}
+/*
+如果 box-sizing: content-box;
+实际宽度 = 200 (width) + 2*10 (padding) + 2*5 (border) = 230px
+如果 box-sizing: border-box;
+实际宽度 = 200px (width 包含了 padding 和 border)
+*/`}
+                    </ExpandableCode>
+                </SecondaryCard>
+
+                <SecondaryCard title="定位 (Positioning)">
+                    <p><code>position</code> 属性用于指定元素的定位类型。配合 <code>top</code>, <code>right</code>, <code>bottom</code>, <code>left</code> 和 <code>z-index</code> 属性可以精确控制元素的位置。</p>
+                    <div className="space-y-3">
+                        <div>
+                            <h5 className="font-semibold"><code>static</code></h5>
+                            <p>默认值。元素按照正常的文档流排列，<code>top</code>, <code>right</code>, <code>bottom</code>, <code>left</code>, <code>z-index</code> 属性无效。</p>
+                        </div>
+                        <div>
+                            <h5 className="font-semibold"><code>relative</code></h5>
+                            <p>元素相对于其正常文档流位置进行定位，但其原始空间仍然保留。可以使用 <code>top</code>, <code>right</code>, <code>bottom</code>, <code>left</code> 调整位置。它会创建一个新的层叠上下文。</p>
+                            <ExpandableCode language="css" maxHeight={80}>
+{`.relative-item {
+    position: relative;
+    top: 10px;
+    left: 20px;
+}`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h5 className="font-semibold"><code>absolute</code></h5>
+                            <p>元素相对于其最近的<strong>已定位的祖先元素</strong>（即 <code>position</code> 非 <code>static</code> 的祖先）进行定位。如果不存在已定位的祖先，则相对于初始包含块（通常是 <code>&lt;body&gt;</code>）。绝对定位的元素会脱离正常的文档流，不占据空间。它会创建一个新的层叠上下文。</p>
+                            <ExpandableCode language="css" maxHeight={100}>
+{`.container {
+    position: relative; /* 为 absolute-item 提供定位上下文 */
+}
+.absolute-item {
+    position: absolute;
+    top: 0;
+    right: 0;
+}`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h5 className="font-semibold"><code>fixed</code></h5>
+                            <p>元素相对于浏览器视口（viewport）进行定位，即使页面滚动，它也会固定在相同的位置。它会脱离正常的文档流，并创建一个新的层叠上下文。</p>
+                            <ExpandableCode language="css" maxHeight={80}>
+{`.fixed-header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    background: #333;
+    color: white;
+    z-index: 1000; /* 确保在顶层 */
+}`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h5 className="font-semibold"><code>sticky</code></h5>
+                            <p>粘性定位是相对定位和固定定位的混合。元素在跨越特定阈值前为相对定位，之后为固定定位。需要指定至少一个 <code>top</code>, <code>right</code>, <code>bottom</code>, <code>left</code>。它也会创建一个新的层叠上下文。</p>
+                            <ExpandableCode language="css" maxHeight={80}>
+{`.sticky-sidebar {
+    position: sticky;
+    top: 20px; /* 当滚动到距离视口顶部20px时变为固定 */
+}`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h5 className="font-semibold"><code>z-index</code></h5>
+                            <p><code>z-index</code> 属性指定了已定位元素（及其子元素）的堆叠顺序。具有较大 <code>z-index</code> 值的元素会覆盖较小值的元素。<code>z-index</code> 只在已定位元素（<code>position</code> 非 <code>static</code>）上有效，并且在同一层叠上下文中比较。</p>
+                        </div>
+                    </div>
+                </SecondaryCard>
+
+                <SecondaryCard title="浮动 (Floats)">
+                    <p><code>float</code> 属性使元素脱离正常的文档流，并向左或向右移动，直到它的外边缘碰到包含块或另一个浮动框的边框为止。文本和内联元素会环绕浮动元素。</p>
+                    <ul className="list-disc pl-5">
+                        <li><code>float: left;</code>: 元素向左浮动。</li>
+                        <li><code>float: right;</code>: 元素向右浮动。</li>
+                        <li><code>float: none;</code> (默认): 元素不浮动。</li>
+                    </ul>
+                    <h4 className="font-semibold mt-3">清除浮动 (Clearing Floats)</h4>
+                    <p>当容器内所有子元素都浮动时，容器的高度可能会塌陷为零。为了解决这个问题，需要清除浮动。<code>clear</code> 属性指定一个元素是否必须移动到浮动元素下方。</p>
+                    <ul className="list-disc pl-5">
+                        <li><code>clear: left;</code>: 清除左浮动。</li>
+                        <li><code>clear: right;</code>: 清除右浮动。</li>
+                        <li><code>clear: both;</code>: 清除左右两侧的浮动。</li>
+                    </ul>
+                    <p>历史上，“clearfix hack” 是一种常用的清除浮动的技术，通过在父容器上使用伪元素实现。现代布局中，可以通过设置父容器的 <code>overflow</code> (如 <code>overflow: auto</code> 或 <code>overflow: hidden</code>，不推荐) 或使用 Flexbox/Grid 容器来自然地包含浮动元素（尽管浮动在其内部的行为可能不是你想要的）。</p>
+                    <h4 className="font-semibold mt-3">用途与现状</h4>
+                    <p>浮动最初设计用于实现文本环绕图片的效果。虽然它曾被广泛用于页面整体布局，但由于其复杂性和副作用（如高度塌陷），现在更推荐使用 Flexbox 和 Grid 进行布局。浮动仍然适用于其原始目的，如文本环绕。</p>
+                    <ExpandableCode language="css" maxHeight={150}>
+{`.image-left {
+    float: left;
+    margin-right: 15px;
+}
+.text-content {
+    /* 文本将环绕 .image-left */
+}
+.clearfix::after { /* 经典的 clearfix hack */
+    content: "";
+    display: table;
+    clear: both;
+}
+.container-with-floats {
+    /* 使用 clearfix hack */
+    /* zoom: 1;  针对旧版IE的另一个hack */
+}`}
+                    </ExpandableCode>
+                </SecondaryCard>
+
+                <SecondaryCard title="层叠上下文 (Stacking Contexts)">
+                    <p>层叠上下文是 HTML 元素的三维概念，其中元素在假想的 Z 轴上（垂直于屏幕）堆叠。当元素形成层叠上下文后，其后代元素的 <code>z-index</code> 值仅在该上下文中进行比较和排序。</p>
+                    <h4 className="font-semibold mt-3">创建层叠上下文的条件 (部分列举):</h4>
+                    <ul className="list-disc pl-5">
+                        <li>文档的根元素 (<code>&lt;html&gt;</code>)。</li>
+                        <li><code>position</code> 值为 <code>absolute</code> 或 <code>relative</code> 且 <code>z-index</code> 值不为 <code>auto</code> 的元素。</li>
+                        <li><code>position</code> 值为 <code>fixed</code> 或 <code>sticky</code> 的元素。</li>
+                        <li><code>opacity</code> 属性值小于 1 的元素。</li>
+                        <li><code>transform</code>, <code>filter</code>, <code>perspective</code>, <code>clip-path</code>, <code>mask</code> 属性值不为 <code>none</code> 的元素。</li>
+                        <li><code>flex</code> 容器的子项，且 <code>z-index</code> 值不为 <code>auto</code>。</li>
+                        <li><code>grid</code> 容器的子项，且 <code>z-index</code> 值不为 <code>auto</code>。</li>
+                    </ul>
+                    <h4 className="font-semibold mt-3"><code>z-index</code> 的作用</h4>
+                    <p><code>z-index</code> 决定了在同一层叠上下文中，元素如何堆叠。具有较高 <code>z-index</code> 的元素会显示在具有较低 <code>z-index</code> 的元素之上。如果两个元素的 <code>z-index</code> 相同，则它们按照在 HTML 中出现的顺序堆叠（后面的覆盖前面的）。</p>
+                    <p>重要的是，不同层叠上下文之间的堆叠顺序由创建这些上下文的元素的 <code>z-index</code> (如果适用) 和它们在 DOM 中的顺序决定。子层叠上下文中的 <code>z-index</code> 值不能与父层叠上下文或兄弟层叠上下文中的 <code>z-index</code> 值直接比较。</p>
+                    <ExpandableCode language="html" maxHeight={200}>
+{`<!-- 示例 -->
+<div style="position: relative; z-index: 1; background: lightblue; padding: 20px;">
+  Div A (z-index: 1)
+  <div style="position: absolute; top: 10px; left: 10px; z-index: 100; background: lightcoral; padding: 10px;">
+    Div A1 (z-index: 100, 但在 Div A 的上下文中)
+  </div>
+</div>
+<div style="position: relative; z-index: 2; background: lightgreen; padding: 20px; margin-top: -30px;">
+  Div B (z-index: 2)
+  <div style="position: absolute; top: 10px; left: 10px; z-index: 50; background: lightyellow; padding: 10px;">
+    Div B1 (z-index: 50, 但在 Div B 的上下文中)
+  </div>
+</div>
+<!-- Div B (和其子元素 B1) 会覆盖 Div A (和其子元素 A1)，因为 Div B 的 z-index 更高 -->
+<!-- Div A1 的 z-index: 100 只在 Div A 内部有意义，不会使其覆盖 Div B -->`}
+                    </ExpandableCode>
+                </SecondaryCard>
+
+                <InfoCard title="其他布局相关属性">
+                    <div className="space-y-3">
+                        <div>
+                            <h5 className="font-semibold"><code>display</code> 属性</h5>
+                            <p><code>display</code> 属性是 CSS 中最基本的属性之一，它定义了元素应生成的框的类型。</p>
+                            <ul className="list-disc pl-5">
+                                <li><code>block</code>: 元素生成一个块级框，前后带有换行符，占据其父容器的整个宽度（除非另有指定）。例如 <code>&lt;div&gt;</code>, <code>&lt;p&gt;</code>, <code>&lt;h1&gt;</code>。</li>
+                                <li><code>inline</code>: 元素生成一个或多个行内框，不强制换行，宽度随内容而定。例如 <code>&lt;span&gt;</code>, <code>&lt;a&gt;</code>, <code>&lt;img&gt;</code>。<code>width</code> 和 <code>height</code> 属性对其无效。</li>
+                                <li><code>inline-block</code>: 元素生成一个块级框，但整个框像行内框一样可以与其他行内内容排在一行。可以设置 <code>width</code>, <code>height</code>, <code>margin</code> (上下), <code>padding</code>。</li>
+                                <li><code>none</code>: 元素不会被显示，并且不占据任何空间（如同它不存在于文档中一样）。</li>
+                                <li>其他值如 <code>flex</code>, <code>grid</code>, <code>table</code> 等会创建特定的布局上下文。</li>
+                            </ul>
+                        </div>
+                        <div>
+                            <h5 className="font-semibold"><code>overflow</code> 属性</h5>
+                            <p><code>overflow</code> 属性指定当内容溢出一个元素的块级容器时如何处理。</p>
+                            <ul className="list-disc pl-5">
+                                <li><code>visible</code> (默认): 内容不会被修剪，会呈现在元素框之外。</li>
+                                <li><code>hidden</code>: 内容会被修剪，并且其余内容不可见。</li>
+                                <li><code>scroll</code>: 内容会被修剪，但浏览器会显示滚动条以便查看其余内容（无论内容是否实际溢出都会显示滚动条）。</li>
+                                <li><code>auto</code>: 如果内容溢出，则浏览器会显示滚动条；否则，内容正常显示。</li>
+                                <li><code>overflow-x</code> 和 <code>overflow-y</code> 可以分别控制水平和垂直方向的溢出。</li>
+                            </ul>
+                        </div>
+                    </div>
+                </InfoCard>
+            </div>
         </QuestionCard>
     );
-} 
+}

--- a/src/components/knowledge/front/css/data/responsive.tsx
+++ b/src/components/knowledge/front/css/data/responsive.tsx
@@ -1,6 +1,5 @@
 import { QuestionCard } from "../../../../base/knowledge_question_card";
 import { InfoCard } from "../../../../card/info_card";
-import { WarningCard } from "../../../../card/warning_card";
 import { SuccessCard } from "../../../../card/success_card";
 import { SecondaryCard } from "../../../../card/secondary_card";
 import { ExpandableCode } from "../../../../base/expandable_code";

--- a/src/components/knowledge/front/css/data/responsive.tsx
+++ b/src/components/knowledge/front/css/data/responsive.tsx
@@ -1,5 +1,9 @@
 import { QuestionCard } from "../../../../base/knowledge_question_card";
 import { InfoCard } from "../../../../card/info_card";
+import { WarningCard } from "../../../../card/warning_card";
+import { SuccessCard } from "../../../../card/success_card";
+import { SecondaryCard } from "../../../../card/secondary_card";
+import { ExpandableCode } from "../../../../base/expandable_code";
 
 interface Props {
     id: string;
@@ -12,13 +16,213 @@ export function FrontCSSResponsive({ id }: Props) {
                 id,
                 title: "CSS 响应式设计",
                 category: "CSS",
-                content: "CSS 响应式设计的原理和实现方法是什么？",
-                tags: ["CSS", "响应式", "媒体查询", "移动端"]
+                content: "什么是响应式网页设计？实现响应式布局的核心技术有哪些，例如媒体查询、流式布局和弹性图片？",
+                tags: ["CSS", "响应式设计", "媒体查询", "流式布局", "弹性图片", "RWD"]
             }}
         >
-            <InfoCard title="敬请期待">
-                <p>响应式设计内容正在准备中...</p>
-            </InfoCard>
+            <div className="space-y-6">
+                <SuccessCard title="核心理念">
+                    <p><strong>响应式网页设计 (Responsive Web Design, RWD)</strong> 的目标是使网站能够根据用户正在使用的设备特性（如屏幕尺寸、分辨率、方向等）自动调整其布局和内容，从而在各种设备（桌面电脑、平板电脑、智能手机）上都能提供<strong>最佳的查看和交互体验</strong>。</p>
+                    <p>这个概念最初由 Ethan Marcotte 提出，其核心思想主要基于三个技术支柱：</p>
+                    <ul className="list-disc pl-5">
+                        <li><strong>流式网格 (Fluid Grids):</strong> 使用相对单位（如百分比）来定义网格布局，使其能够灵活适应不同屏幕宽度。</li>
+                        <li><strong>弹性图片/媒体 (Flexible Images/Media):</strong> 使图片和媒体内容也能在不同尺寸的容器中自适应缩放。</li>
+                        <li><strong>媒体查询 (Media Queries):</strong> CSS3 的一个模块，允许开发者根据设备的特定特性（如视口宽度）应用不同的样式规则。</li>
+                    </ul>
+                </SuccessCard>
+
+                <SecondaryCard title="媒体查询 (Media Queries)">
+                    <p>媒体查询是实现响应式设计的核心技术。它允许我们根据设备的特定条件（媒体特性）应用不同的 CSS 样式。</p>
+                    <h4 className="font-semibold mt-3">基本语法</h4>
+                    <p><code>@media [media-type] (media-feature-rule) { /* CSS 规则 */ }</code></p>
+                    <ul className="list-disc pl-5">
+                        <li><strong><code>@media</code>:</strong> 声明一个媒体查询块。</li>
+                        <li><strong>媒体类型 (Media Types):</strong> 可选，指定设备类型。常见值：
+                            <ul className="list-disc pl-5">
+                                <li><code>all</code>: 适用于所有设备 (默认值)。</li>
+                                <li><code>screen</code>: 适用于彩色电脑屏幕。</li>
+                                <li><code>print</code>: 适用于打印预览模式或打印机。</li>
+                                {/* <li><code>speech</code>: 适用于屏幕阅读器等。</li> */}
+                            </ul>
+                        </li>
+                        <li><strong>媒体特性规则 (Media Feature Rules):</strong> 描述设备的具体特性，如 <code>min-width</code>, <code>max-width</code>, <code>min-height</code>, <code>max-height</code>, <code>orientation</code> (<code>portrait</code> | <code>landscape</code>), <code>aspect-ratio</code>, <code>resolution</code> 等。</li>
+                        <li><strong>逻辑操作符:</strong>
+                            <ul className="list-disc pl-5">
+                                <li><code>and</code>: 连接多个媒体特性规则，必须都满足。</li>
+                                <li><code>not</code>: 对整个媒体查询取反 (较少用)。</li>
+                                <li><code>,</code> (逗号): 相当于 <code>or</code>，满足任一查询即可。</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <ExpandableCode language="css" maxHeight={180}>
+{`/* 当视口宽度小于等于 600px 时应用 */
+@media screen and (max-width: 600px) {
+    body {
+        font-size: 14px;
+    }
+    .sidebar {
+        display: none;
+    }
+}
+
+/* 当视口宽度在 601px 到 900px 之间时应用 */
+@media (min-width: 601px) and (max-width: 900px) {
+    .main-content {
+        width: 70%;
+    }
+}
+
+/* 针对打印样式 */
+@media print {
+    nav, footer { display: none; }
+    body { color: black; background: white; }
+}`}
+                    </ExpandableCode>
+                    <h4 className="font-semibold mt-3">Viewport Meta 标签</h4>
+                    <p>为了确保在移动设备上正确缩放和渲染，需要在 HTML 的 <code>&lt;head&gt;</code> 中添加 viewport meta 标签：</p>
+                    <ExpandableCode language="html" maxHeight={80}>
+{`<meta name="viewport" content="width=device-width, initial-scale=1.0">`}
+                    </ExpandableCode>
+                    <ul className="list-disc pl-5 text-sm">
+                        <li><code>width=device-width</code>: 设置视口的宽度等于设备的屏幕宽度。</li>
+                        <li><code>initial-scale=1.0</code>: 设置初始缩放级别为 1。</li>
+                    </ul>
+                    <h4 className="font-semibold mt-3">常用断点 (Breakpoints) 示例</h4>
+                    <p className="text-sm">断点是媒体查询中用于区分不同设备尺寸的阈值。选择合适的断点取决于具体设计和内容。以下是一些常见的参考值：</p>
+                    <ul className="list-disc pl-5 text-sm">
+                        <li><strong>小型设备 (手机):</strong> <code>max-width: 600px</code> 或 <code>max-width: 767px</code></li>
+                        <li><strong>中型设备 (平板电脑):</strong> <code>min-width: 601px</code> and <code>max-width: 992px</code> (或类似范围)</li>
+                        <li><strong>大型设备 (桌面):</strong> <code>min-width: 993px</code> (或类似范围)</li>
+                    </ul>
+                    <p className="text-sm">更推荐基于内容本身来确定断点，而不是针对特定设备。</p>
+                </SecondaryCard>
+
+                <SecondaryCard title="流式布局与弹性单位 (Fluid Layouts & Flexible Units)">
+                    <p>流式布局是指网页元素的尺寸使用相对单位（如百分比）而不是固定单位（如像素），使得布局能够随视口大小变化而平滑地调整。</p>
+                    <h4 className="font-semibold mt-3">百分比 (%)</h4>
+                    <p>将元素的宽度、外边距、内边距等设置为百分比，使其相对于其父容器的相应尺寸进行缩放。</p>
+                    <ExpandableCode language="css" maxHeight={100}>
+{`.container {
+    width: 100%;
+}
+.column {
+    width: 50%; /* 占据父容器宽度的一半 */
+    float: left; /* (传统方式，Flexbox/Grid 更佳) */
+    padding: 2%;
+}`}
+                    </ExpandableCode>
+                    <h4 className="font-semibold mt-3">相对单位</h4>
+                    <ul className="list-disc pl-5">
+                        <li><strong><code>em</code>:</strong> 相对于当前元素的字体大小。如果用于 <code>font-size</code>，则相对于父元素的字体大小。</li>
+                        <li><strong><code>rem</code> (root em):</strong> 相对于根元素 (<code>&lt;html&gt;</code>) 的字体大小。这使得可以更容易地通过改变根字体大小来全局缩放元素。</li>
+                        <li><strong><code>vw</code> (viewport width):</strong> 相对于视口宽度的 1%。<code>10vw</code> 等于视口宽度的 10%。</li>
+                        <li><strong><code>vh</code> (viewport height):</strong> 相对于视口高度的 1%。</li>
+                        <li><strong><code>vmin</code>:</strong> <code>vw</code> 和 <code>vh</code> 中较小的值。</li>
+                        <li><strong><code>vmax</code>:</strong> <code>vw</code> 和 <code>vh</code> 中较大的值。</li>
+                    </ul>
+                    <p>使用这些单位可以创建真正流动的、可伸缩的布局和文本。</p>
+                    <ExpandableCode language="css" maxHeight={120}>
+{`html {
+    font-size: 16px; /* rem 的基准 */
+}
+body {
+    font-size: 1rem; /* 等于 16px */
+}
+h1 {
+    font-size: 2.5rem; /* 2.5 * 16px = 40px */
+    margin-bottom: 1em; /* 等于 h1 当前字体大小的 1 倍 */
+}
+.hero-banner {
+    width: 100vw; /* 占满整个视口宽度 */
+    height: 50vh; /* 占视口高度的一半 */
+}`}
+                    </ExpandableCode>
+                </SecondaryCard>
+
+                <SecondaryCard title="弹性图片与媒体 (Flexible Images & Media)">
+                    <p>确保图片、视频和其他媒体内容能够在其容器内自适应缩放，防止溢出或显示不当。</p>
+                    <h4 className="font-semibold mt-3">基本弹性图片</h4>
+                    <p>最简单的方法是为图片设置 <code>max-width: 100%;</code> 和 <code>height: auto;</code>。这样图片最大不会超过其容器宽度，并且高度会按比例自动调整。</p>
+                    <ExpandableCode language="css" maxHeight={80}>
+{`img, video, iframe {
+    max-width: 100%;
+    height: auto;
+}`}
+                    </ExpandableCode>
+                    <h4 className="font-semibold mt-3">使用 <code>&lt;picture&gt;</code> 元素或 <code>srcset</code> 属性</h4>
+                    <p>为了在不同屏幕尺寸和分辨率下提供最优化的图片（例如，为高分屏提供更高清的图片，为小屏设备提供较小的图片以节省带宽），可以使用 <code>&lt;picture&gt;</code> 元素或 <code>&lt;img&gt;</code> 标签的 <code>srcset</code> 和 <code>sizes</code> 属性。</p>
+                    <ExpandableCode language="html" maxHeight={200}>
+{`<!-- 使用 <picture> 元素 -->
+<picture>
+  <source media="(min-width: 800px)" srcset="large-image.jpg">
+  <source media="(min-width: 480px)" srcset="medium-image.jpg">
+  <img src="small-image.jpg" alt="A responsive image">
+</picture>
+
+<!-- 使用 srcset 和 sizes 属性 -->
+<img src="small.jpg"
+     srcset="medium.jpg 1000w, large.jpg 2000w"
+     sizes="(min-width: 60em) 25vw, (min-width: 40em) 50vw, 100vw"
+     alt="Another responsive image">
+`}
+                    </ExpandableCode>
+                    <h4 className="font-semibold mt-3">响应式视频/iframe (宽高比技巧)</h4>
+                    <p>对于具有固定宽高比的嵌入式内容（如 YouTube 视频），可以利用 CSS 的 "padding-bottom hack" 来维持其宽高比，使其响应式缩放。</p>
+                    <ExpandableCode language="html" maxHeight={180}>
+{`<!-- HTML -->
+<div class="video-container">
+  <iframe src="https://www.youtube.com/embed/your-video-id"
+          frameborder="0"
+          allowfullscreen></iframe>
+</div>
+
+<!-- CSS -->
+<style>
+.video-container {
+    position: relative;
+    padding-bottom: 56.25%; /* 16:9 aspect ratio (9 / 16 = 0.5625) */
+    height: 0;
+    overflow: hidden;
+}
+.video-container iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}
+</style>`}
+                    </ExpandableCode>
+                </SecondaryCard>
+
+                <InfoCard title="响应式设计策略与模式">
+                    <div className="space-y-3">
+                        <div>
+                            <h5 className="font-semibold">移动优先 (Mobile-First) vs. 桌面优先 (Desktop-First)</h5>
+                            <ul className="list-disc pl-5">
+                                <li><strong>移动优先:</strong> 首先为小型设备设计和开发核心功能和样式，然后使用媒体查询逐步增强大屏幕版本的体验。这种方法通常能带来更简洁、性能更好的移动体验。</li>
+                                <li><strong>桌面优先:</strong> 首先为桌面大屏幕设计，然后通过媒体查询逐步删减或调整布局以适应小屏幕。这种方法在历史上更常见，但现在移动优先被认为是更佳实践。</li>
+                            </ul>
+                        </div>
+                        <div>
+                            <h5 className="font-semibold">常见响应式布局模式</h5>
+                            <p>有一些经过验证的模式可以帮助组织和调整不同屏幕尺寸下的内容：</p>
+                            <ul className="list-disc pl-5">
+                                <li><strong>Mostly Fluid (大部分流式):</strong> 主要依赖流式网格，在大屏幕上可能会有最大宽度限制。在小屏幕上，列可能会堆叠。</li>
+                                <li><strong>Column Drop (列下沉):</strong> 当屏幕空间不足时，多列布局中的列会逐个下沉并堆叠。</li>
+                                <li><strong>Layout Shifter (布局切换):</strong> 内容块在不同断点下会显著改变其排列方式和位置，而不仅仅是简单的堆叠。</li>
+                                <li><strong>Off-Canvas (画布外导航):</strong> 对于复杂的导航菜单，在小屏幕上将其隐藏在屏幕外，通过点击按钮滑出。</li>
+                                {/* <li><strong>Tiny Tweaks (微小调整):</strong> 针对特定断点对字体大小、边距、内边距等进行细微调整。</li> */}
+                            </ul>
+                            <p className="text-sm">选择哪种模式取决于具体的内容和设计需求。</p>
+                        </div>
+                        <div>
+                            <h5 className="font-semibold">测试的重要性</h5>
+                            <p>在多种真实设备和浏览器上测试响应式设计至关重要。浏览器开发工具中的设备模拟器是一个很好的起点，但不能完全替代真实设备测试，尤其是在交互和性能方面。</p>
+                        </div>
+                    </div>
+                </InfoCard>
+            </div>
         </QuestionCard>
     );
-} 
+}

--- a/src/components/knowledge/go/data/go_basics.tsx
+++ b/src/components/knowledge/go/data/go_basics.tsx
@@ -1,0 +1,342 @@
+import { QuestionCard } from "../../../../base/knowledge_question_card";
+import { InfoCard } from "../../../../card/info_card";
+import { WarningCard } from "../../../../card/warning_card";
+import { SuccessCard } from "../../../../card/success_card";
+import { SecondaryCard } from "../../../../card/secondary_card";
+import { ExpandableCode } from "../../../../base/expandable_code";
+
+interface Props {
+    id: string;
+}
+
+export function GoBasics({ id }: Props) {
+    return (
+        <QuestionCard
+            question={{
+                id,
+                title: "Go 语言基础",
+                category: "Go",
+                content: "Go 语言的基础语法、数据类型、控制流程以及核心概念是什么？",
+                tags: ["Go", "Golang", "基础语法", "数据类型", "控制流程"]
+            }}
+        >
+            <div className="space-y-6">
+                <SuccessCard title="核心概要">
+                    <p>Go 语言（或称 Golang）是由 Google 设计的一门开源编程语言。它的设计目标是<strong>简洁、高效、易于构建并发程序以及拥有强大的工具链</strong>。Go 语言特别适合于网络服务、分布式系统、命令行工具等场景的开发。</p>
+                </SuccessCard>
+
+                <SecondaryCard title="基本语法与声明">
+                    <div className="space-y-4">
+                        <div>
+                            <h4 className="font-semibold">包 (Packages)</h4>
+                            <p>每个 Go 程序都由包构成。程序从 <code>main</code> 包开始运行。</p>
+                            <ExpandableCode language="go" maxHeight={100}>
+{`package main
+
+import "fmt" // 导入 fmt 包，用于格式化 I/O
+
+// main 函数是程序的入口
+func main() {
+    fmt.Println("Hello, Go!")
+}`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold">变量 (Variables)</h4>
+                            <p>使用 <code>var</code> 关键字声明变量。也可以使用 <code>:=</code> 进行短变量声明（只能在函数内部）。</p>
+                            <ExpandableCode language="go" maxHeight={150}>
+{`package main
+
+import "fmt"
+
+func main() {
+    var name string = "Go Developer" // 显式声明类型
+    var version = 1.18             // 类型推断
+    website := "golang.org"        // 短变量声明
+
+    fmt.Println(name, "version", version, "website:", website)
+
+    var ( // 批量声明
+        a int
+        b bool
+    )
+    a = 10
+    b = true
+    fmt.Println(a, b)
+}`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold">常量 (Constants)</h4>
+                            <p>使用 <code>const</code> 关键字声明常量。常量的值在编译时确定。</p>
+                            <ExpandableCode language="go" maxHeight={100}>
+{`package main
+
+import "fmt"
+
+const Pi = 3.14159
+const (
+    StatusOK = 200
+    StatusNotFound = 404
+)
+
+func main() {
+    fmt.Println("Pi:", Pi)
+    fmt.Println("Status OK:", StatusOK)
+}`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold">函数 (Functions)</h4>
+                            <p>使用 <code>func</code> 关键字声明函数。可以有多个返回值。</p>
+                            <ExpandableCode language="go" maxHeight={120}>
+{`package main
+
+import "fmt"
+
+// add 函数接收两个 int 参数，返回一个 int
+func add(x int, y int) int {
+    return x + y
+}
+
+// swap 函数返回两个 string
+func swap(x, y string) (string, string) {
+    return y, x
+}
+
+func main() {
+    fmt.Println("add(42, 13) =", add(42, 13))
+    a, b := swap("hello", "world")
+    fmt.Println(a, b) // "world hello"
+}`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold">注释 (Comments)</h4>
+                            <p>单行注释以 <code>//</code> 开头，多行注释以 <code>/* ... */</code> 包裹。</p>
+                            <ExpandableCode language="go" maxHeight={80}>
+{`// 这是单行注释
+
+/*
+这是
+多行注释
+*/`}
+                            </ExpandableCode>
+                        </div>
+                    </div>
+                </SecondaryCard>
+
+                <SecondaryCard title="数据类型">
+                    <div className="space-y-4">
+                        <div>
+                            <h4 className="font-semibold">基本类型</h4>
+                            <ul className="list-disc pl-5">
+                                <li><strong>布尔型:</strong> <code>bool</code> (<code>true</code>, <code>false</code>)</li>
+                                <li><strong>字符串:</strong> <code>string</code> (UTF-8 编码)</li>
+                                <li><strong>数值类型:</strong>
+                                    <ul className="list-disc pl-5">
+                                        <li>整数: <code>int</code>, <code>int8</code>, <code>int16</code>, <code>int32</code>, <code>int64</code>, <code>uint</code>, <code>uint8</code> (<code>byte</code>), <code>uint16</code>, <code>uint32</code>, <code>uint64</code>, <code>uintptr</code></li>
+                                        <li>浮点数: <code>float32</code>, <code>float64</code></li>
+                                        <li>复数: <code>complex64</code>, <code>complex128</code></li>
+                                        <li><code>rune</code>: <code>int32</code> 的别名，表示一个 Unicode 码点</li>
+                                        <li><code>byte</code>: <code>uint8</code> 的别名</li>
+                                    </ul>
+                                </li>
+                            </ul>
+                            <ExpandableCode language="go" maxHeight={100}>
+{`var isActive bool = true
+var message string = "你好, 世界"
+var count int = -100
+var price float64 = 99.99
+var char rune = '世' // 注意是单引号
+var b byte = 'a'`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold">复合类型</h4>
+                            <ul className="list-disc pl-5">
+                                <li><strong>数组 (Array):</strong> 固定长度的同类型元素序列。<code>[n]T</code></li>
+                                <li><strong>切片 (Slice):</strong> 动态长度的同类型元素序列，是对数组的引用。<code>[]T</code></li>
+                                <li><strong>映射 (Map):</strong>键值对的无序集合。<code>map[K]V</code></li>
+                                <li><strong>结构体 (Struct):</strong>将不同类型的字段组合在一起。<code>struct { ... }</code></li>
+                            </ul>
+                            <ExpandableCode language="go" maxHeight={200}>
+{`// 数组
+var arr [3]int = [3]int{1, 2, 3}
+
+// 切片
+var s []int = []int{1, 2, 3, 4, 5}
+s = append(s, 6) // 添加元素
+
+// 映射
+m := make(map[string]int)
+m["one"] = 1
+m["two"] = 2
+
+// 结构体
+type Person struct {
+    Name string
+    Age  int
+}
+p := Person{Name: "Alice", Age: 30}`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold">指针 (Pointers)</h4>
+                            <p>存储变量的内存地址。使用 <code>*</code> 定义指针类型，<code>&</code> 获取地址，<code>*</code> 解引用。</p>
+                             <ExpandableCode language="go" maxHeight={100}>
+{`var x int = 10
+var p *int = &x // p 指向 x
+fmt.Println(*p) // 输出 10
+*p = 20         // 修改 x 的值为 20
+fmt.Println(x)  // 输出 20`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold">类型转换 (Type Conversion)</h4>
+                            <p>Go 语言中没有隐式类型转换，需要显式转换。格式：<code>T(v)</code> 将值 <code>v</code> 转换为类型 <code>T</code>。</p>
+                            <ExpandableCode language="go" maxHeight={80}>
+{`var i int = 42
+var f float64 = float64(i)
+var u uint = uint(f)
+// var b byte = byte(i) // 如果 i 超出 byte 范围，可能会截断`}
+                            </ExpandableCode>
+                        </div>
+                    </div>
+                </SecondaryCard>
+
+                <SecondaryCard title="控制流程">
+                    <div className="space-y-4">
+                        <div>
+                            <h4 className="font-semibold"><code>if/else</code></h4>
+                            <p>条件语句。条件表达式不需要括号，但执行体必须有大括号。</p>
+                            <ExpandableCode language="go" maxHeight={120}>
+{`x := 10
+if x > 5 {
+    fmt.Println("x is greater than 5")
+} else if x < 5 {
+    fmt.Println("x is less than 5")
+} else {
+    fmt.Println("x is 5")
+}
+
+// if 语句可以包含一个简短的初始化语句
+if y := calculate(); y > 100 {
+    fmt.Println("y is greater than 100")
+}`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold"><code>for</code></h4>
+                            <p>Go 只有一种循环结构：<code>for</code> 循环。支持多种形式。</p>
+                            <ExpandableCode language="go" maxHeight={180}>
+{`// 1. 基本的 for 循环 (类似 C 的 for)
+for i := 0; i < 5; i++ {
+    fmt.Println(i)
+}
+
+// 2. 条件循环 (类似 C 的 while)
+sum := 1
+for sum < 1000 {
+    sum += sum
+}
+
+// 3. 无限循环 (需要 break 或 return)
+// for {
+//     // ...
+// }
+
+// 4. for...range 遍历 (用于数组、切片、字符串、映射、通道)
+nums := []int{1, 2, 3}
+for index, value := range nums {
+    fmt.Printf("index: %d, value: %d\\n", index, value)
+}
+
+m := map[string]string{"a": "apple", "b": "banana"}
+for key, value := range m {
+    fmt.Printf("%s -> %s\\n", key, value)
+}`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold"><code>switch</code></h4>
+                            <p>多路条件选择。Go 的 <code>switch</code> 更灵活，<code>case</code> 默认有 <code>break</code>。可以使用 <code>fallthrough</code> 强制执行下一个 <code>case</code>。</p>
+                            <ExpandableCode language="go" maxHeight={150}>
+{`day := "Sunday"
+switch day {
+case "Monday", "Tuesday", "Wednesday", "Thursday", "Friday":
+    fmt.Println("Weekday")
+case "Saturday", "Sunday":
+    fmt.Println("Weekend")
+default:
+    fmt.Println("Invalid day")
+}
+
+// switch true (无表达式的 switch，可替代 if/else if 链)
+score := 85
+switch {
+case score >= 90:
+    fmt.Println("A")
+case score >= 80:
+    fmt.Println("B")
+default:
+    fmt.Println("C")
+}`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold"><code>defer</code></h4>
+                            <p><code>defer</code> 语句会将其后面跟随的函数调用推迟到外层函数执行完毕（即将返回）之前执行。常用于资源释放、解锁等操作。</p>
+                            <ExpandableCode language="go" maxHeight={100}>
+{`func cleanup() {
+    fmt.Println("Cleaning up...")
+}
+
+func process() {
+    defer cleanup() // cleanup 会在 process 返回前执行
+    fmt.Println("Processing...")
+    // return
+} // cleanup 在这里执行`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold"><code>panic</code> 和 <code>recover</code></h4>
+                            <p><code>panic</code> 用于产生运行时恐慌，中断正常流程。<code>recover</code> 用于捕获 <code>panic</code>，仅在 <code>defer</code> 函数中有效。</p>
+                            <ExpandableCode language="go" maxHeight={120}>
+{`func mayPanic() {
+    defer func() {
+        if r := recover(); r != nil {
+            fmt.Println("Recovered from panic:", r)
+        }
+    }() // 立即执行的匿名函数
+
+    fmt.Println("Before panic")
+    panic("something went wrong")
+    // fmt.Println("After panic") // 不会执行
+}
+
+func main() {
+    mayPanic()
+    fmt.Println("Program continues after panic recovery")
+}`}
+                            </ExpandableCode>
+                        </div>
+                    </div>
+                </SecondaryCard>
+
+                <InfoCard title="关键特性">
+                    <ul className="list-disc pl-5 space-y-2">
+                        <li><strong>静态类型 (Static Typing):</strong> 变量类型在编译时确定，有助于早期发现错误。</li>
+                        <li><strong>垃圾回收 (Garbage Collection):</strong> 自动管理内存，简化开发。</li>
+                        <li><strong>无类 (No Classes):</strong> Go 使用结构体 (<code>struct</code>) 和方法 (<code>method</code>) 来实现面向对象的特性，但没有传统意义上的类和继承。</li>
+                        <li><strong>接口 (Interfaces):</strong> Go 的接口是隐式实现的。任何类型只要实现了接口中定义的所有方法，就被认为实现了该接口，无需显式声明。</li>
+                        <li><strong>并发 (Concurrency):</strong> Go 通过 goroutine 和 channel 提供了强大的并发支持，易于编写高并发程序。</li>
+                        <li><strong>强大的标准库 (Rich Standard Library):</strong> 提供了大量内置包，覆盖网络、I/O、加密、文本处理等。</li>
+                        <li><strong>快速编译 (Fast Compilation):</strong> Go 的编译速度非常快，提升开发效率。</li>
+                        <li><strong>工具链 (Tooling):</strong> 提供了统一的工具集，如 <code>go fmt</code> (格式化), <code>go test</code> (测试), <code>go build</code> (构建) 等。</li>
+                    </ul>
+                </InfoCard>
+            </div>
+        </QuestionCard>
+    );
+}

--- a/src/components/knowledge/go/data/go_basics.tsx
+++ b/src/components/knowledge/go/data/go_basics.tsx
@@ -158,7 +158,7 @@ var b byte = 'a'`}
                                 <li><strong>数组 (Array):</strong> 固定长度的同类型元素序列。<code>[n]T</code></li>
                                 <li><strong>切片 (Slice):</strong> 动态长度的同类型元素序列，是对数组的引用。<code>[]T</code></li>
                                 <li><strong>映射 (Map):</strong>键值对的无序集合。<code>map[K]V</code></li>
-                                <li><strong>结构体 (Struct):</strong>将不同类型的字段组合在一起。<code>struct { ... }</code></li>
+                                <li><strong>结构体 (Struct):</strong>将不同类型的字段组合在一起。<code>struct  ...</code></li>
                             </ul>
                             <ExpandableCode language="go" maxHeight={200}>
 {`// 数组

--- a/src/components/knowledge/go/data/go_basics.tsx
+++ b/src/components/knowledge/go/data/go_basics.tsx
@@ -185,11 +185,9 @@ p := Person{Name: "Alice", Age: 30}`}
                             <h4 className="font-semibold">指针 (Pointers)</h4>
                             <p>存储变量的内存地址。使用 <code>*</code> 定义指针类型，<code>&</code> 获取地址，<code>*</code> 解引用。</p>
                              <ExpandableCode language="go" maxHeight={100}>
-{`var x int = 10
-var p *int = &x // p 指向 x
-fmt.Println(*p) // 输出 10
-*p = 20         // 修改 x 的值为 20
-fmt.Println(x)  // 输出 20`}
+{`package main
+import "fmt"
+func main() { fmt.Println("Test") }`}
                             </ExpandableCode>
                         </div>
                         <div>

--- a/src/components/knowledge/go/data/go_basics.tsx
+++ b/src/components/knowledge/go/data/go_basics.tsx
@@ -1,9 +1,8 @@
-import { QuestionCard } from "../../../../base/knowledge_question_card";
-import { InfoCard } from "../../../../card/info_card";
-import { WarningCard } from "../../../../card/warning_card";
-import { SuccessCard } from "../../../../card/success_card";
-import { SecondaryCard } from "../../../../card/secondary_card";
-import { ExpandableCode } from "../../../../base/expandable_code";
+import { QuestionCard } from "../../../base/knowledge_question_card";
+import { InfoCard } from "../../../card/info_card";
+import { SuccessCard } from "../../../card/success_card";
+import { SecondaryCard } from "../../../card/secondary_card";
+import { ExpandableCode } from "../../../base/expandable_code";
 
 interface Props {
     id: string;

--- a/src/components/knowledge/go/data/go_concurrency.tsx
+++ b/src/components/knowledge/go/data/go_concurrency.tsx
@@ -1,0 +1,347 @@
+import { QuestionCard } from "../../../../base/knowledge_question_card";
+import { InfoCard } from "../../../../card/info_card";
+import { WarningCard } from "../../../../card/warning_card";
+import { SuccessCard } from "../../../../card/success_card";
+import { SecondaryCard } from "../../../../card/secondary_card";
+import { ExpandableCode } from "../../../../base/expandable_code";
+
+interface Props {
+    id: string;
+}
+
+export function GoConcurrency({ id }: Props) {
+    return (
+        <QuestionCard
+            question={{
+                id,
+                title: "Go 并发编程：Goroutines 与 Channels",
+                category: "Go",
+                content: "Go语言中 Goroutines 和 Channels 是如何工作的？它们如何实现高效并发？",
+                tags: ["Go", "Golang", "并发", "Goroutines", "Channels", "CSP"]
+            }}
+        >
+            <div className="space-y-6">
+                <SuccessCard title="核心概要">
+                    <p>Go 语言的并发模型基于<strong>通信顺序进程 (CSP, Communicating Sequential Processes)</strong>。它通过轻量级的 <strong>Goroutines</strong> 和用于它们之间通信的 <strong>Channels</strong> 来实现。Go 的核心理念是：<strong>“不要通过共享内存来通信；而是通过通信来共享内存。”</strong> 这使得编写高并发程序更为简单和安全。</p>
+                </SuccessCard>
+
+                <SecondaryCard title="Goroutines">
+                    <div className="space-y-4">
+                        <div>
+                            <h4 className="font-semibold">什么是 Goroutines?</h4>
+                            <p>Goroutine 是 Go 语言中与其他函数或方法同时运行的函数或方法。可以认为 Goroutine 是轻量级的线程，由 Go 运行时管理。它们占用的内存非常小（几 KB），并且可以动态伸缩，使得可以轻松创建成千上万个 Goroutine。</p>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold">启动 Goroutine</h4>
+                            <p>使用 <code>go</code> 关键字在函数或方法调用前加上，即可启动一个新的 Goroutine。</p>
+                            <ExpandableCode language="go" maxHeight={120}>
+{`package main
+
+import (
+    "fmt"
+    "time"
+)
+
+func say(s string) {
+    for i := 0; i < 3; i++ {
+        fmt.Println(s)
+        time.Sleep(100 * time.Millisecond)
+    }
+}
+
+func main() {
+    go say("Hello") // 启动一个新的 Goroutine 执行 say("Hello")
+    say("World")    // 当前 Goroutine 执行 say("World")
+    // 注意：程序在 main Goroutine 结束后会立即退出，可能不会等待其他 Goroutine 执行完毕
+}`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold"><code>sync.WaitGroup</code> 等待 Goroutines</h4>
+                            <p>为了等待多个 Goroutine 完成，可以使用 <code>sync.WaitGroup</code>。它有三个方法：<code>Add(delta int)</code> 增加计数器，<code>Done()</code> 减少计数器，<code>Wait()</code> 阻塞直到计数器为零。</p>
+                            <ExpandableCode language="go" maxHeight={180}>
+{`package main
+
+import (
+    "fmt"
+    "sync"
+    "time"
+)
+
+func worker(id int, wg *sync.WaitGroup) {
+    defer wg.Done() // 在函数返回时通知 WaitGroup 完成
+
+    fmt.Printf("Worker %d starting\\n", id)
+    time.Sleep(time.Second)
+    fmt.Printf("Worker %d done\\n", id)
+}
+
+func main() {
+    var wg sync.WaitGroup
+
+    for i := 1; i <= 3; i++ {
+        wg.Add(1) // 增加计数器
+        go worker(i, &wg)
+    }
+
+    wg.Wait() // 等待所有 Goroutine 完成
+    fmt.Println("All workers done")
+}`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold">匿名函数 Goroutines</h4>
+                            <p>可以直接使用匿名函数启动 Goroutine。</p>
+                            <ExpandableCode language="go" maxHeight={100}>
+{`package main
+
+import (
+    "fmt"
+    "time"
+)
+
+func main() {
+    go func(msg string) {
+        fmt.Println(msg)
+    }("Going") // 启动匿名函数 Goroutine 并传递参数
+
+    time.Sleep(time.Second) // 等待 Goroutine 执行
+    fmt.Println("Done")
+}`}
+                            </ExpandableCode>
+                        </div>
+                    </div>
+                </SecondaryCard>
+
+                <SecondaryCard title="Channels">
+                    <div className="space-y-4">
+                        <div>
+                            <h4 className="font-semibold">什么是 Channels?</h4>
+                            <p>Channel 是用于 Goroutine 之间通信的管道。你可以把它想象成一个类型化的导管，通过它你可以发送和接收特定类型的值。操作符 <code>&lt;-</code> 用于发送或接收值。</p>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold">创建、发送与接收</h4>
+                            <p>使用 <code>make(chan val-type)</code> 创建 Channel。发送和接收操作在另一端准备好之前都会阻塞。</p>
+                            <ExpandableCode language="go" maxHeight={150}>
+{`package main
+
+import "fmt"
+
+func main() {
+    messages := make(chan string) // 创建一个字符串类型的 Channel
+
+    go func() {
+        messages <- "ping" // 发送 "ping" 到 Channel
+    }()
+
+    msg := <-messages // 从 Channel 接收消息
+    fmt.Println(msg)  // 输出 "ping"
+}`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold">缓冲 Channels (Buffered Channels)</h4>
+                            <p>默认情况下，Channel 是无缓冲的，意味着只有在对应的接收方准备好接收时，发送方才会发送成功。缓冲 Channel 允许在没有相应接收方的情况下，限制数量的值存储在 Channel 中。使用 <code>make(chan val-type, buffer-capacity)</code> 创建。</p>
+                            <ExpandableCode language="go" maxHeight={100}>
+{`package main
+
+import "fmt"
+
+func main() {
+    // 创建一个可以缓冲2个字符串的 Channel
+    messages := make(chan string, 2)
+
+    messages <- "buffered"
+    messages <- "channel"
+    // messages <- "overflow" // 如果再发送一个会导致死锁，因为缓冲区已满且无接收者
+
+    fmt.Println(<-messages)
+    fmt.Println(<-messages)
+}`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold">关闭 Channel 与 <code>for...range</code></h4>
+                            <p>发送者可以 <code>close</code> 一个 Channel 来表示没有更多的值会被发送。接收者可以通过 <code>v, ok := &lt;-ch</code> 的第二个返回值 <code>ok</code> 来测试 Channel 是否已经关闭。<code>for i := range c</code> 循环会不断从 Channel 接收值，直到它被关闭。</p>
+                            <ExpandableCode language="go" maxHeight={180}>
+{`package main
+
+import "fmt"
+
+func main() {
+    jobs := make(chan int, 5)
+    done := make(chan bool)
+
+    go func() {
+        for {
+            j, more := <-jobs // 'more' 为 false 表示 jobs 已关闭
+            if more {
+                fmt.Println("received job", j)
+            } else {
+                fmt.Println("received all jobs")
+                done <- true
+                return
+            }
+        }
+    }()
+
+    for j := 1; j <= 3; j++ {
+        jobs <- j
+        fmt.Println("sent job", j)
+    }
+    close(jobs) // 关闭 jobs Channel
+    fmt.Println("sent all jobs")
+
+    <-done // 等待 Goroutine 完成
+
+    // 使用 for...range 遍历 Channel
+    queue := make(chan string, 2)
+    queue <- "one"
+    queue <- "two"
+    close(queue)
+
+    for elem := range queue { // 会在 Channel 关闭后自动结束循环
+        fmt.Println(elem)
+    }
+}`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold">定向 Channels (Directional Channels)</h4>
+                            <p>当将 Channel 作为函数参数时，可以指定其方向（只发送或只接收）。这增加了程序的类型安全性。</p>
+                            <ExpandableCode language="go" maxHeight={120}>
+{`package main
+
+import "fmt"
+
+// ping 函数只能向 pings Channel 发送数据 (chan<- string)
+func ping(pings chan<- string, msg string) {
+    pings <- msg
+}
+
+// pong 函数只能从 pings Channel 接收数据 (<-chan string)
+// 并向 pongs Channel 发送数据 (chan<- string)
+func pong(pings <-chan string, pongs chan<- string) {
+    msg := <-pings
+    pongs <- msg
+}
+
+func main() {
+    pings := make(chan string, 1)
+    pongs := make(chan string, 1)
+    ping(pings, "passed message")
+    pong(pings, pongs)
+    fmt.Println(<-pongs)
+}`}
+                            </ExpandableCode>
+                        </div>
+                    </div>
+                </SecondaryCard>
+
+                <SecondaryCard title="Select 语句">
+                    <div className="space-y-4">
+                        <div>
+                            <h4 className="font-semibold">目的与语法</h4>
+                            <p><code>select</code> 语句让一个 Goroutine 可以等待多个通信操作。<code>select</code> 会阻塞，直到其某个 <code>case</code> 可以运行，然后它就会执行那个 <code>case</code>。如果多个 <code>case</code> 同时准备就绪，它会随机选择一个。</p>
+                            <ExpandableCode language="go" maxHeight={200}>
+{`package main
+
+import (
+    "fmt"
+    "time"
+)
+
+func main() {
+    c1 := make(chan string)
+    c2 := make(chan string)
+
+    go func() {
+        time.Sleep(1 * time.Second)
+        c1 <- "one"
+    }()
+    go func() {
+        time.Sleep(2 * time.Second)
+        c2 <- "two"
+    }()
+
+    for i := 0; i < 2; i++ { // 等待两个消息
+        select {
+        case msg1 := <-c1:
+            fmt.Println("received", msg1)
+        case msg2 := <-c2:
+            fmt.Println("received", msg2)
+        }
+    }
+}`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold">超时 (Timeout) 与默认 (Default)</h4>
+                            <p><code>select</code> 的 <code>default</code> case 使得可以实现非阻塞的发送、接收，甚至是非阻塞的多路 <code>select</code>。<code>time.After</code> 可以在 <code>select</code> 中用于实现超时。</p>
+                            <ExpandableCode language="go" maxHeight={180}>
+{`package main
+
+import (
+    "fmt"
+    "time"
+)
+
+func main() {
+    ch := make(chan string, 1)
+
+    // 非阻塞接收
+    select {
+    case msg := <-ch:
+        fmt.Println("received message", msg)
+    default:
+        fmt.Println("no message received")
+    }
+
+    // 非阻塞发送
+    msg := "hi"
+    select {
+    case ch <- msg:
+        fmt.Println("sent message", msg)
+    default:
+        fmt.Println("no message sent (channel full or no receiver)")
+    }
+
+    // 带超时的 select
+    c1 := make(chan string, 1)
+    go func() {
+        time.Sleep(2 * time.Second)
+        c1 <- "result 1"
+    }()
+
+    select {
+    case res := <-c1:
+        fmt.Println(res)
+    case <-time.After(1 * time.Second): // 1秒后超时
+        fmt.Println("timeout 1")
+    }
+}`}
+                            </ExpandableCode>
+                        </div>
+                    </div>
+                </SecondaryCard>
+
+                <InfoCard title="并发模式与最佳实践">
+                    <ul className="list-disc pl-5 space-y-2">
+                        <li><strong>Worker Pools:</strong> 使用一组 Goroutine 来处理任务队列，控制并发数量。</li>
+                        <li><strong>Rate Limiting:</strong> 控制资源访问速率，例如每秒处理 N 个请求。</li>
+                        <li><strong>Fan-in, Fan-out:</strong>
+                            <ul className="list-disc pl-5">
+                                <li><strong>Fan-out:</strong> 一个 Goroutine 将工作分发给多个 Goroutine 处理。</li>
+                                <li><strong>Fan-in:</strong> 多个 Goroutine 的输出合并到一个 Channel 中。</li>
+                            </ul>
+                        </li>
+                        <li><strong>避免死锁 (Deadlocks):</strong> 当 Goroutine 互相等待对方释放资源时发生。注意 Channel 操作的阻塞特性，确保有对应的发送/接收方，或使用缓冲/<code>select default</code>。</li>
+                        <li><strong>竞争条件 (Race Conditions):</strong> 当多个 Goroutine 并发访问共享数据且至少有一个进行写操作时，可能发生竞争条件。Go 提供了 <code>go run -race</code> 或 <code>go test -race</code> 来检测竞争条件。</li>
+                        <li><strong>使用 Context:</strong> 对于需要取消、超时或传递请求范围数据的操作，使用 <code>context.Context</code>。</li>
+                        <li><strong>Channel 的所有权:</strong> 通常，创建 Channel 的 Goroutine 也是其所有者，负责关闭它。只应由发送方关闭 Channel，绝不能由接收方关闭。</li>
+                    </ul>
+                </InfoCard>
+            </div>
+        </QuestionCard>
+    );
+}

--- a/src/components/knowledge/go/data/go_concurrency.tsx
+++ b/src/components/knowledge/go/data/go_concurrency.tsx
@@ -1,9 +1,8 @@
-import { QuestionCard } from "../../../../base/knowledge_question_card";
-import { InfoCard } from "../../../../card/info_card";
-import { WarningCard } from "../../../../card/warning_card";
-import { SuccessCard } from "../../../../card/success_card";
-import { SecondaryCard } from "../../../../card/secondary_card";
-import { ExpandableCode } from "../../../../base/expandable_code";
+import { QuestionCard } from "../../../base/knowledge_question_card";
+import { InfoCard } from "../../../card/info_card";
+import { SuccessCard } from "../../../card/success_card";
+import { SecondaryCard } from "../../../card/secondary_card";
+import { ExpandableCode } from "../../../base/expandable_code";
 
 interface Props {
     id: string;

--- a/src/components/knowledge/go/data/go_databases.tsx
+++ b/src/components/knowledge/go/data/go_databases.tsx
@@ -1,9 +1,8 @@
-import { QuestionCard } from "../../../../base/knowledge_question_card";
-import { InfoCard } from "../../../../card/info_card";
-import { WarningCard } from "../../../../card/warning_card";
-import { SuccessCard } from "../../../../card/success_card";
-import { SecondaryCard } from "../../../../card/secondary_card";
-import { ExpandableCode } from "../../../../base/expandable_code";
+import { QuestionCard } from "../../../base/knowledge_question_card";
+import { InfoCard } from "../../../card/info_card";
+import { SuccessCard } from "../../../card/success_card";
+import { SecondaryCard } from "../../../card/secondary_card";
+import { ExpandableCode } from "../../../base/expandable_code";
 
 interface Props {
     id: string;

--- a/src/components/knowledge/go/data/go_databases.tsx
+++ b/src/components/knowledge/go/data/go_databases.tsx
@@ -1,0 +1,248 @@
+import { QuestionCard } from "../../../../base/knowledge_question_card";
+import { InfoCard } from "../../../../card/info_card";
+import { WarningCard } from "../../../../card/warning_card";
+import { SuccessCard } from "../../../../card/success_card";
+import { SecondaryCard } from "../../../../card/secondary_card";
+import { ExpandableCode } from "../../../../base/expandable_code";
+
+interface Props {
+    id: string;
+}
+
+export function GoDatabases({ id }: Props) {
+    return (
+        <QuestionCard
+            question={{
+                id,
+                title: "Go 操作数据库",
+                category: "Go",
+                content: "如何在 Go 语言中连接和操作数据库？包括标准库 `database/sql` 和常用 ORM。",
+                tags: ["Go", "Golang", "数据库", "SQL", "database/sql", "ORM", "GORM"]
+            }}
+        >
+            <div className="space-y-6">
+                <SuccessCard title="核心概要">
+                    <p>数据库交互是大多数应用程序的核心功能。Go 语言通过标准库 <code>database/sql</code> 包提供了一套通用的、与具体数据库驱动无关的接口来执行 SQL 操作。此外，诸如 <strong>GORM</strong> 等对象关系映射器 (ORM) 提供了更高级别的抽象，简化了数据库操作和模型管理。</p>
+                </SuccessCard>
+
+                <SecondaryCard title="标准库 `database/sql`">
+                    <div className="space-y-4">
+                        <div>
+                            <h4 className="font-semibold">概述</h4>
+                            <p><code>database/sql</code> 包本身不提供任何数据库驱动，而是定义了一系列接口。开发者需要配合特定数据库的驱动程序（如 <code>github.com/go-sql-driver/mysql</code>, <code>github.com/lib/pq</code> for PostgreSQL）来使用。</p>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold">连接数据库</h4>
+                            <p>使用 <code>sql.Open(driverName, dataSourceName)</code> 来打开一个数据库连接。<code>dataSourceName</code> (DSN) 的格式因数据库驱动而异。</p>
+                            <ExpandableCode language="go" maxHeight={150}>
+{`package main
+
+import (
+    "database/sql"
+    "fmt"
+    _ "github.com/go-sql-driver/mysql" // 匿名导入 MySQL 驱动
+)
+
+func main() {
+    // DSN 格式: user:password@tcp(host:port)/dbname
+    db, err := sql.Open("mysql", "user:password@tcp(127.0.0.1:3306)/testdb")
+    if err != nil {
+        panic(err.Error())
+    }
+    defer db.Close() // 确保在函数返回时关闭连接
+
+    err = db.Ping() // 检查连接是否成功
+    if err != nil {
+        panic(err.Error())
+    }
+    fmt.Println("Successfully connected to MySQL!")
+}`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold">执行查询</h4>
+                            <ul className="list-disc pl-5">
+                                <li><code>db.QueryRow()</code>: 执行只返回单行的查询（例如通过 ID 查询）。</li>
+                                <li><code>db.Query()</code>: 执行返回多行的查询。</li>
+                                <li><code>db.Exec()</code>: 执行不返回行的语句（如 INSERT, UPDATE, DELETE）。</li>
+                            </ul>
+                            <ExpandableCode language="go" maxHeight={180}>
+{`// 查询单行
+var name string
+var age int
+err = db.QueryRow("SELECT name, age FROM users WHERE id = ?", 1).Scan(&name, &age)
+if err != nil {
+    if err == sql.ErrNoRows {
+        // 处理未找到行的情况
+    } else {
+        // 处理其他错误
+    }
+}
+
+// 查询多行
+rows, err := db.Query("SELECT id, name FROM users WHERE age > ?", 30)
+if err != nil { /* ... */ }
+defer rows.Close()
+
+for rows.Next() {
+    var id int
+    var name string
+    if err := rows.Scan(&id, &name); err != nil { /* ... */ }
+    fmt.Printf("ID: %d, Name: %s\\n", id, name)
+}
+if err := rows.Err(); err != nil { /* 检查循环中是否有错误 ... */ }
+
+// 执行非查询语句
+result, err := db.Exec("INSERT INTO users (name, age) VALUES (?, ?)", "Alice", 25)
+if err != nil { /* ... */ }
+lastInsertId, _ := result.LastInsertId()
+rowsAffected, _ := result.RowsAffected()`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold">预处理语句 (Prepared Statements)</h4>
+                            <p>预处理语句可以提高性能并有效防止 SQL 注入。使用 <code>db.Prepare()</code> 创建，然后可以多次执行。</p>
+                            <ExpandableCode language="go" maxHeight={120}>
+{`stmt, err := db.Prepare("INSERT INTO users (name, age) VALUES (?, ?)")
+if err != nil { /* ... */ }
+defer stmt.Close()
+
+_, err = stmt.Exec("Bob", 30)
+if err != nil { /* ... */ }
+_, err = stmt.Exec("Charlie", 35)
+if err != nil { /* ... */ }`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold">事务 (Transactions)</h4>
+                            <p>使用 <code>db.Begin()</code> 开始一个事务，然后使用 <code>tx.Commit()</code> 或 <code>tx.Rollback()</code> 提交或回滚。事务内的操作使用 <code>tx.Query()</code>, <code>tx.Exec()</code> 等。</p>
+                            <ExpandableCode language="go" maxHeight={150}>
+{`tx, err := db.Begin()
+if err != nil { /* ... */ }
+
+_, err = tx.Exec("UPDATE accounts SET balance = balance - ? WHERE id = ?", 100, 1)
+if err != nil {
+    tx.Rollback() // 出错时回滚
+    // ...
+    return
+}
+_, err = tx.Exec("UPDATE accounts SET balance = balance + ? WHERE id = ?", 100, 2)
+if err != nil {
+    tx.Rollback()
+    // ...
+    return
+}
+
+err = tx.Commit() // 提交事务
+if err != nil { /* ... */ }`}
+                            </ExpandableCode>
+                        </div>
+                         <div>
+                            <h4 className="font-semibold">CRUD 示例 (简要)</h4>
+                            <ExpandableCode language="go" maxHeight={200}>
+{`// Create
+db.Exec("INSERT INTO products (name, price) VALUES (?, ?)", "Laptop", 999.99)
+
+// Read (Single)
+var productName string
+var productPrice float64
+db.QueryRow("SELECT name, price FROM products WHERE id = ?", 1).Scan(&productName, &productPrice)
+
+// Read (Multiple) - 见上方 db.Query() 示例
+
+// Update
+db.Exec("UPDATE products SET price = ? WHERE id = ?", 1099.99, 1)
+
+// Delete
+db.Exec("DELETE FROM products WHERE id = ?", 1)`}
+                            </ExpandableCode>
+                        </div>
+                    </div>
+                </SecondaryCard>
+
+                <SecondaryCard title="ORM 简介 - GORM">
+                    <div className="space-y-4">
+                        <div>
+                            <h4 className="font-semibold">什么是 ORM?</h4>
+                            <p>对象关系映射器 (ORM) 是一种编程技术，用于在关系数据库和面向对象编程语言之间转换数据。它允许开发者使用面向对象的方式来操作数据库，而无需编写大量的 SQL 语句。</p>
+                            <p><strong>优点:</strong> 提高开发效率、减少重复的 SQL 代码、面向对象操作、某些情况下有助于数据库迁移。</p>
+                            <p><strong>缺点:</strong> 可能产生低效的 SQL、学习曲线、隐藏了 SQL 的复杂性、对于复杂查询可能不够灵活。</p>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold">GORM 简介</h4>
+                            <p>GORM 是 Go 语言中一个功能强大、广受欢迎的 ORM 库。它提供了模型定义、关联、事务、迁移等丰富特性。</p>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold">GORM 基本使用</h4>
+                            <ExpandableCode language="go" maxHeight={250}>
+{`package main
+
+import (
+    "fmt"
+    "gorm.io/driver/mysql"
+    "gorm.io/gorm"
+)
+
+// 定义模型 (Model)
+type Product struct {
+    gorm.Model // 内嵌 gorm.Model, 包含 ID, CreatedAt, UpdatedAt, DeletedAt
+    Code  string
+    Price uint
+}
+
+func main() {
+    dsn := "user:password@tcp(127.0.0.1:3306)/testdb?charset=utf8mb4&parseTime=True&loc=Local"
+    db, err := gorm.Open(mysql.Open(dsn), &gorm.Config{})
+    if err != nil {
+        panic("failed to connect database")
+    }
+
+    // 自动迁移 (创建或更新表结构)
+    db.AutoMigrate(&Product{})
+
+    // Create
+    db.Create(&Product{Code: "D42", Price: 100})
+
+    // Read
+    var product Product
+    db.First(&product, 1) // 根据整型主键查找
+    fmt.Printf("Product (ID 1): %+v\\n", product)
+
+    db.First(&product, "code = ?", "D42") // 根据条件查找
+    fmt.Printf("Product (Code D42): %+v\\n", product)
+
+    // Update - 更新单个字段
+    db.Model(&product).Update("Price", 200)
+    // Update - 更新多个字段
+    db.Model(&product).Updates(Product{Price: 200, Code: "F42"}) // 仅更新非零值字段
+    db.Model(&product).Updates(map[string]interface{}{"Price": 200, "Code": "F42"})
+
+    // Delete
+    // db.Delete(&product, 1) // 删除 ID 为 1 的产品 (软删除，如果模型包含 gorm.DeletedAt)
+}
+`}
+                            </ExpandableCode>
+                        </div>
+                        <p className="text-sm text-base-content/70">GORM 功能非常丰富，包括关联（一对一、一对多、多对多）、钩子、事务、预加载等。这仅仅是一个入门介绍。</p>
+                    </div>
+                </SecondaryCard>
+
+                <InfoCard title="选择与最佳实践">
+                    <ul className="list-disc pl-5 space-y-2">
+                        <li><strong><code>database/sql</code> vs. ORM:</strong>
+                            <ul className="list-disc pl-5">
+                                <li>对于简单的应用或需要极致性能和 SQL 控制的场景，<code>database/sql</code> 是不错的选择。</li>
+                                <li>对于复杂的应用、需要快速开发、模型关系复杂的场景，ORM (如 GORM) 可以显著提高效率。</li>
+                            </ul>
+                        </li>
+                        <li><strong>连接池:</strong> <code>database/sql</code> 内部维护一个连接池。可以通过 <code>db.SetMaxOpenConns()</code>, <code>db.SetMaxIdleConns()</code>, <code>db.SetConnMaxLifetime()</code> 来配置。合理配置连接池对性能至关重要。</li>
+                        <li><strong>处理 <code>sql.ErrNoRows</code>:</strong> 在使用 <code>QueryRow().Scan()</code> 时，如果查询没有返回行，会返回 <code>sql.ErrNoRows</code>。务必检查并妥善处理此错误，而不是将其视为普通错误。</li>
+                        <li><strong>SQL 注入:</strong> 始终优先使用预处理语句 (Prepared Statements) 或 ORM 提供的查询构建器来防止 SQL 注入攻击。避免直接拼接字符串来构造 SQL 查询。</li>
+                        <li><strong>错误处理:</strong> Go 的错误处理机制要求显式检查每个可能返回错误的操作。不要忽略数据库操作返回的错误。</li>
+                        <li><strong>关闭资源:</strong> 确保使用 <code>defer rows.Close()</code> 和 <code>defer stmt.Close()</code> 来关闭 <code>sql.Rows</code> 和 <code>sql.Stmt</code>，防止资源泄漏。<code>db.Close()</code> 也应在程序结束时调用。</li>
+                    </ul>
+                </InfoCard>
+            </div>
+        </QuestionCard>
+    );
+}

--- a/src/components/knowledge/go/data/go_testing.tsx
+++ b/src/components/knowledge/go/data/go_testing.tsx
@@ -1,0 +1,246 @@
+import { QuestionCard } from "../../../../base/knowledge_question_card";
+import { InfoCard } from "../../../../card/info_card";
+import { WarningCard } from "../../../../card/warning_card";
+import { SuccessCard } from "../../../../card/success_card";
+import { SecondaryCard } from "../../../../card/secondary_card";
+import { ExpandableCode } from "../../../../base/expandable_code";
+
+interface Props {
+    id: string;
+}
+
+export function GoTesting({ id }: Props) {
+    return (
+        <QuestionCard
+            question={{
+                id,
+                title: "Go 测试",
+                category: "Go",
+                content: "如何在 Go 语言中编写单元测试和基准测试？Go 的测试工具有哪些特性？",
+                tags: ["Go", "Golang", "测试", "单元测试", "基准测试", "testing"]
+            }}
+        >
+            <div className="space-y-6">
+                <SuccessCard title="核心概要">
+                    <p>测试是保证软件质量的关键环节。Go 语言内置了强大的测试支持，通过标准库中的 <code>testing</code> 包和命令行工具 <code>go test</code>，开发者可以方便地编写和执行单元测试、基准测试以及示例测试。Go 的测试哲学强调简洁、约定优于配置以及与源码的紧密集成。</p>
+                </SuccessCard>
+
+                <SecondaryCard title="单元测试 (Unit Tests)">
+                    <div className="space-y-4">
+                        <div>
+                            <h4 className="font-semibold">测试文件与函数签名</h4>
+                            <p>单元测试代码位于与被测试源码文件同目录下的 <code>_test.go</code> 文件中。测试函数必须以 <code>Test</code> 开头，并接收一个 <code>*testing.T</code> 类型的参数。</p>
+                            <ExpandableCode language="go" maxHeight={120}>
+{`// mypackage/math.go
+package mypackage
+
+func Add(a, b int) int {
+    return a + b
+}
+
+// mypackage/math_test.go
+package mypackage
+
+import "testing"
+
+func TestAdd(t *testing.T) {
+    // ... test logic ...
+}`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold">测试报告与断言</h4>
+                            <p><code>*testing.T</code> 提供了多种方法来报告测试状态：</p>
+                            <ul className="list-disc pl-5">
+                                <li><code>t.Log(...interface{})</code>: 记录信息（仅在测试失败或使用 <code>-v</code> 选项时显示）。</li>
+                                <li><code>t.Error(...interface{})</code>: 报告测试失败，但继续执行当前测试函数。</li>
+                                <li><code>t.Errorf(format string, ...interface{})</code>: 同 <code>t.Error</code>，但使用格式化字符串。</li>
+                                <li><code>t.Fatal(...interface{})</code>: 报告测试失败，并立即停止当前测试函数的执行（后续代码不会运行）。</li>
+                                <li><code>t.Fatalf(format string, ...interface{})</code>: 同 <code>t.Fatal</code>，但使用格式化字符串。</li>
+                                <li><code>t.Fail()</code>: 将测试标记为失败，但继续执行。<code>t.Error</code> 和 <code>t.Fatal</code> 内部会调用它。</li>
+                                <li><code>t.FailNow()</code>: 将测试标记为失败，并停止执行。<code>t.Fatal</code> 内部会调用它。</li>
+                                <li><code>t.Skip(...interface{})</code>: 跳过当前测试。</li>
+                            </ul>
+                            <p>Go 标准库不直接提供断言库，通常通过简单的 <code>if</code> 条件判断。外部库如 <code>testify/assert</code> 或 <code>testify/require</code> 提供了更丰富的断言方法。</p>
+                            <ExpandableCode language="go" maxHeight={150}>
+{`func TestAdd(t *testing.T) {
+    sum := Add(1, 2)
+    expected := 3
+    if sum != expected {
+        t.Errorf("Add(1, 2) = %d; want %d", sum, expected)
+    }
+
+    // 使用 testify/assert (外部库示例)
+    // import "github.com/stretchr/testify/assert"
+    // assert.Equal(t, expected, sum, "they should be equal")
+}`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold">表驱动测试 (Table-Driven Tests)</h4>
+                            <p>对于需要测试多种输入和输出组合的函数，表驱动测试是一种常用的模式，可以使测试代码更清晰、易于维护。</p>
+                            <ExpandableCode language="go" maxHeight={200}>
+{`func TestAddTableDriven(t *testing.T) {
+    var tests = []struct {
+        a, b     int
+        expected int
+        name     string // 可选，用于 t.Run 子测试命名
+    }{
+        {1, 2, 3, "1+2=3"},
+        {0, 0, 0, "0+0=0"},
+        {-1, 1, 0, "-1+1=0"},
+        {10, -5, 5, "10+(-5)=5"},
+    }
+
+    for _, tt := range tests {
+        // 使用 t.Run 创建子测试，方便定位失败用例
+        t.Run(tt.name, func(t *testing.T) {
+            if sum := Add(tt.a, tt.b); sum != tt.expected {
+                t.Errorf("Add(%d, %d) = %d; want %d", tt.a, tt.b, sum, tt.expected)
+            }
+        })
+    }
+}`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold">测试覆盖率</h4>
+                            <p>使用 <code>go test -cover</code> 命令可以查看测试覆盖率。<code>go test -coverprofile=coverage.out</code> 生成覆盖率报告文件，然后可以使用 <code>go tool cover -html=coverage.out</code> 查看 HTML 格式的详细报告。</p>
+                        </div>
+                    </div>
+                </SecondaryCard>
+
+                <SecondaryCard title="基准测试 (Benchmark Tests)">
+                    <div className="space-y-4">
+                        <div>
+                            <h4 className="font-semibold">基准测试函数签名</h4>
+                            <p>基准测试函数以 <code>Benchmark</code> 开头，并接收一个 <code>*testing.B</code> 类型的参数。</p>
+                            <ExpandableCode language="go" maxHeight={100}>
+{`// mypackage/math_test.go
+package mypackage
+
+import "testing"
+
+func BenchmarkAdd(b *testing.B) {
+    // ... benchmark logic ...
+}`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold">使用 <code>b.N</code></h4>
+                            <p>基准测试函数中的循环体应该执行 <code>b.N</code> 次。<code>b.N</code> 的值由测试框架动态调整，以确保测试运行足够长的时间来获得可靠的度量。</p>
+                            <ExpandableCode language="go" maxHeight={100}>
+{`func BenchmarkAdd(b *testing.B) {
+    for i := 0; i < b.N; i++ {
+        Add(100, 200) // 要进行基准测试的代码
+    }
+}`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold">控制计时器</h4>
+                            <p><code>b.ResetTimer()</code> 可以重置计时器，忽略之前的设置代码所花费的时间。<code>b.StartTimer()</code> 和 <code>b.StopTimer()</code> 可以用于在循环内外分别启动和停止计时，以排除不想计入基准测试时间的部分。</p>
+                            <ExpandableCode language="go" maxHeight={120}>
+{`func BenchmarkHeavySetup(b *testing.B) {
+    // 模拟一些耗时的设置操作
+    // time.Sleep(time.Second)
+    b.ResetTimer() // 重置计时器，不包括设置时间
+    for i := 0; i < b.N; i++ {
+        Add(1, 2)
+    }
+}`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold">运行与结果解读</h4>
+                            <p>使用 <code>go test -bench=.</code> 运行当前包下的所有基准测试。<code>-benchmem</code> 参数可以显示内存分配信息。</p>
+                            <p>结果通常包括：测试名称、<code>b.N</code> 的值（迭代次数）、每次操作的平均时间 (ns/op)、每次操作的内存分配 (B/op)、每次操作的内存分配次数 (allocs/op)。</p>
+                            <ExpandableCode language="text" maxHeight={80}>
+{`$ go test -bench=. -benchmem
+goos: linux
+goarch: amd64
+pkg: mypackage
+BenchmarkAdd-8         1000000000           0.25 ns/op          0 B/op          0 allocs/op
+PASS
+ok      mypackage       0.300s`}
+                            </ExpandableCode>
+                        </div>
+                    </div>
+                </SecondaryCard>
+
+                <SecondaryCard title="其他测试特性">
+                    <div className="space-y-4">
+                        <div>
+                            <h4 className="font-semibold">示例测试 (Example-based Tests)</h4>
+                            <p>示例测试函数以 <code>Example</code> 开头。它们既作为文档（会显示在 GoDoc 中），也作为测试（如果输出与注释中的 <code>// Output:</code> 匹配）。</p>
+                            <ExpandableCode language="go" maxHeight={120}>
+{`package mypackage
+
+import "fmt"
+
+func ExampleAdd() {
+    sum := Add(5, 10)
+    fmt.Println(sum)
+    // Output: 15
+}
+
+func ExampleAdd_negative() { // 可以为不同场景创建多个示例
+    sum := Add(-1, -2)
+    fmt.Println(sum)
+    // Output: -3
+}`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold">子测试 (Subtests)</h4>
+                            <p>使用 <code>t.Run(name string, f func(t *testing.T))</code> 可以在一个测试函数内创建多个独立的子测试。这对于组织测试用例（如表驱动测试）和获取更细致的测试报告非常有用。</p>
+                            <p>（见上方“表驱动测试”中的示例）</p>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold">测试初始化与清理 (Setup and Teardown)</h4>
+                            <p>可以使用 <code>TestMain(m *testing.M)</code> 函数来为整个包的测试执行全局的初始化和清理操作。它接收一个 <code>*testing.M</code> 参数，通过调用 <code>m.Run()</code> 来执行包内的所有测试。</p>
+                            <ExpandableCode language="go" maxHeight={150}>
+{`package mypackage
+
+import (
+    "fmt"
+    "os"
+    "testing"
+)
+
+func TestMain(m *testing.M) {
+    fmt.Println("Setting up tests for the whole package...")
+    // 进行设置操作，例如连接数据库、创建临时文件等
+
+    exitCode := m.Run() // 执行包内所有测试
+
+    fmt.Println("Tearing down tests for the whole package...")
+    // 进行清理操作
+
+    os.Exit(exitCode)
+}`}
+                            </ExpandableCode>
+                            <p>对于单个测试函数的局部设置和清理，通常直接在测试函数内部或使用 <code>defer</code> 语句实现。</p>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold">Mocking 与接口</h4>
+                            <p>Go 的接口机制天然地为测试提供了便利。通过定义接口，可以轻松地为依赖项（如数据库、外部服务）创建 mock 实现，从而在测试中隔离被测单元。</p>
+                        </div>
+                    </div>
+                </SecondaryCard>
+
+                <InfoCard title="测试最佳实践">
+                    <ul className="list-disc pl-5 space-y-2">
+                        <li><strong>为公共 API 编写测试:</strong> 优先测试包导出的函数和方法。</li>
+                        <li><strong>追求良好的测试覆盖率:</strong> 但不要盲目追求 100%，关注关键逻辑和边界条件。</li>
+                        <li><strong>保持测试独立:</strong> 测试用例之间不应有依赖关系或共享状态，以便可以独立运行或并行运行。</li>
+                        <li><strong>确保测试快速:</strong> 缓慢的测试会降低开发效率。对于耗时的集成测试，可以考虑将其与单元测试分开。</li>
+                        <li><strong>使用描述性的测试名称:</strong> 特别是子测试，清晰的名称有助于快速定位问题。</li>
+                        <li><strong>测试边界条件和错误情况:</strong> 不仅仅测试正常路径，还要覆盖无效输入、错误处理等。</li>
+                        <li><strong>定期运行测试:</strong> 将测试集成到 CI/CD 流程中，确保代码变更不会破坏现有功能。</li>
+                    </ul>
+                </InfoCard>
+            </div>
+        </QuestionCard>
+    );
+}

--- a/src/components/knowledge/go/data/go_testing.tsx
+++ b/src/components/knowledge/go/data/go_testing.tsx
@@ -1,9 +1,8 @@
-import { QuestionCard } from "../../../../base/knowledge_question_card";
-import { InfoCard } from "../../../../card/info_card";
-import { WarningCard } from "../../../../card/warning_card";
-import { SuccessCard } from "../../../../card/success_card";
-import { SecondaryCard } from "../../../../card/secondary_card";
-import { ExpandableCode } from "../../../../base/expandable_code";
+import { QuestionCard } from "../../../base/knowledge_question_card";
+import { InfoCard } from "../../../card/info_card";
+import { SuccessCard } from "../../../card/success_card";
+import { SecondaryCard } from "../../../card/secondary_card";
+import { ExpandableCode } from "../../../base/expandable_code";
 
 interface Props {
     id: string;

--- a/src/components/knowledge/go/data/go_web_development.tsx
+++ b/src/components/knowledge/go/data/go_web_development.tsx
@@ -1,0 +1,300 @@
+import { QuestionCard } from "../../../../base/knowledge_question_card";
+import { InfoCard } from "../../../../card/info_card";
+import { WarningCard } from "../../../../card/warning_card";
+import { SuccessCard } from "../../../../card/success_card";
+import { SecondaryCard } from "../../../../card/secondary_card";
+import { ExpandableCode } from "../../../../base/expandable_code";
+
+interface Props {
+    id: string;
+}
+
+export function GoWebDevelopment({ id }: Props) {
+    return (
+        <QuestionCard
+            question={{
+                id,
+                title: "Go Web 开发",
+                category: "Go",
+                content: "如何使用 Go 语言进行 Web 开发？包括标准库 `net/http` 和常用框架如 Gin 或 Echo。",
+                tags: ["Go", "Golang", "Web开发", "net/http", "Gin", "Echo", "API"]
+            }}
+        >
+            <div className="space-y-6">
+                <SuccessCard title="核心概要">
+                    <p>Go 语言凭借其<strong>出色的性能、简洁的语法以及强大的并发处理能力</strong>，成为构建现代 Web 应用和 API 的热门选择。其<strong>强大的标准库 `net/http`</strong> 提供了构建 Web 服务的基础功能，而诸如 <strong>Gin、Echo 等流行框架</strong>则进一步简化了开发流程，提供了更高级的特性如路由、中间件和模板渲染等。</p>
+                </SuccessCard>
+
+                <SecondaryCard title="标准库 `net/http`">
+                    <div className="space-y-4">
+                        <div>
+                            <h4 className="font-semibold">创建简单 HTTP 服务器</h4>
+                            <p>使用 <code>net/http</code> 包可以轻松启动一个 HTTP 服务器。</p>
+                            <ExpandableCode language="go" maxHeight={150}>
+{`package main
+
+import (
+    "fmt"
+    "net/http"
+)
+
+func helloHandler(w http.ResponseWriter, r *http.Request) {
+    fmt.Fprintf(w, "Hello, Web with Go!")
+}
+
+func main() {
+    http.HandleFunc("/hello", helloHandler) // 注册处理器函数
+    fmt.Println("Starting server on :8080")
+    err := http.ListenAndServe(":8080", nil) // nil 表示使用默认的 ServeMux
+    if err != nil {
+        fmt.Println("Error starting server:", err)
+    }
+}`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold">处理请求与响应</h4>
+                            <p>处理器函数接收 <code>http.ResponseWriter</code> 和 <code>*http.Request</code> 两个参数。<code>ResponseWriter</code> 用于构建 HTTP 响应，<code>Request</code> 包含了 HTTP 请求的信息。</p>
+                            <ExpandableCode language="go" maxHeight={120}>
+{`func requestInfoHandler(w http.ResponseWriter, r *http.Request) {
+    fmt.Fprintf(w, "Method: %s\\n", r.Method)
+    fmt.Fprintf(w, "URL Path: %s\\n", r.URL.Path)
+    fmt.Fprintf(w, "Host: %s\\n", r.Host)
+    // ... 更多请求信息
+}`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold">路由 (Routing)</h4>
+                            <p><code>http.HandleFunc</code> 用于将 URL 路径映射到处理器函数。<code>http.ServeMux</code> 是 HTTP 请求路由器（也称为 multiplexer），可以创建自定义的路由器实例。</p>
+                            <ExpandableCode language="go" maxHeight={150}>
+{`package main
+
+import (
+    "fmt"
+    "net/http"
+)
+
+func main() {
+    mux := http.NewServeMux() // 创建新的 ServeMux
+    mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+        fmt.Fprint(w, "Default Route")
+    })
+    mux.HandleFunc("/users", func(w http.ResponseWriter, r *http.Request) {
+        fmt.Fprint(w, "Users Route")
+    })
+
+    fmt.Println("Starting server on :8081 with custom mux")
+    http.ListenAndServe(":8081", mux) // 使用自定义 mux
+}`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold">查询参数和表单数据</h4>
+                            <p>通过 <code>r.URL.Query()</code> 获取查询参数，<code>r.ParseForm()</code> 和 <code>r.FormValue()</code> 或 <code>r.PostFormValue()</code> 获取表单数据。</p>
+                            <ExpandableCode language="go" maxHeight={150}>
+{`func queryHandler(w http.ResponseWriter, r *http.Request) {
+    // /query?name=Alice&age=30
+    name := r.URL.Query().Get("name")
+    age := r.URL.Query().Get("age")
+    fmt.Fprintf(w, "Name: %s, Age: %s", name, age)
+}
+
+func formHandler(w http.ResponseWriter, r *http.Request) {
+    if r.Method == http.MethodPost {
+        r.ParseForm() // 解析 application/x-www-form-urlencoded 数据
+        username := r.FormValue("username")
+        // username := r.PostFormValue("username") // 等价
+        fmt.Fprintf(w, "Username from form: %s", username)
+        return
+    }
+    // 显示表单 (简单示例)
+    w.Header().Set("Content-Type", "text/html")
+    fmt.Fprint(w, "<form method='POST'><input name='username'/><button type='submit'>Submit</button></form>")
+}`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold">提供静态文件</h4>
+                            <p><code>http.FileServer</code> 和 <code>http.StripPrefix</code> 用于提供静态文件（如 CSS、JS、图片）。</p>
+                            <ExpandableCode language="go" maxHeight={100}>
+{`// 假设 ./static 目录下存放静态文件
+fs := http.FileServer(http.Dir("./static/"))
+// 访问 /static/style.css 会映射到 ./static/style.css
+http.Handle("/static/", http.StripPrefix("/static/", fs))`}
+                            </ExpandableCode>
+                        </div>
+                         <div>
+                            <h4 className="font-semibold">中间件 (Middleware)</h4>
+                            <p>中间件是一种包装处理器函数以添加额外功能（如日志、认证、CORS）的常用模式。它本质上是一个接收 <code>http.Handler</code> 并返回新的 <code>http.Handler</code> 的函数。</p>
+                            <ExpandableCode language="go" maxHeight={150}>
+{`func loggingMiddleware(next http.Handler) http.Handler {
+    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        fmt.Printf("Request: %s %s\\n", r.Method, r.URL.Path)
+        next.ServeHTTP(w, r) // 调用下一个处理器
+        // 可以在这里记录响应信息
+    })
+}
+
+func main() {
+    mux := http.NewServeMux()
+    mux.HandleFunc("/hello", helloHandler)
+
+    loggedMux := loggingMiddleware(mux) // 应用中间件
+
+    http.ListenAndServe(":8080", loggedMux)
+}`}
+                            </ExpandableCode>
+                        </div>
+                    </div>
+                </SecondaryCard>
+
+                <SecondaryCard title="Web 框架简介 (Gin/Echo)">
+                    <div className="space-y-4">
+                        <div>
+                            <h4 className="font-semibold">为什么使用框架?</h4>
+                            <p>虽然标准库 <code>net/http</code> 很强大，但对于更复杂的应用，Web 框架可以提供诸多便利：</p>
+                            <ul className="list-disc pl-5">
+                                <li><strong>高级路由:</strong> 参数化路由、路由组、更灵活的匹配规则。</li>
+                                <li><strong>中间件管理:</strong> 更易于组合和管理中间件链。</li>
+                                <li><strong>请求绑定与校验:</strong> 自动将请求数据（JSON, XML, Query等）绑定到结构体并进行校验。</li>
+                                <li><strong>模板渲染:</strong> 集成模板引擎，方便动态生成 HTML。</li>
+                                <li><strong>错误处理:</strong> 统一的错误处理机制。</li>
+                                <li><strong>上下文管理:</strong> 通常提供一个上下文对象，在请求处理链中传递数据。</li>
+                            </ul>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold">Gin 框架</h4>
+                            <p>Gin 是一个高性能的 HTTP Web 框架，以其类似 Martini 的 API 和出色的性能著称。</p>
+                            <ExpandableCode language="go" maxHeight={120}>
+{`package main
+
+import (
+    "net/http"
+    "github.com/gin-gonic/gin"
+)
+
+func main() {
+    r := gin.Default() // Default() 包含了 Logger 和 Recovery 中间件
+    r.GET("/ping", func(c *gin.Context) {
+        c.JSON(http.StatusOK, gin.H{
+            "message": "pong",
+        })
+    })
+    r.Run(":8082") // 默认监听并在 0.0.0.0:8080 上启动服务
+}`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold">Echo 框架</h4>
+                            <p>Echo 是一个高性能、可扩展、极简的 Go Web 框架。它提供了强大的路由、中间件生态和灵活的模板渲染。</p>
+                            <ExpandableCode language="go" maxHeight={120}>
+{`package main
+
+import (
+    "net/http"
+    "github.com/labstack/echo/v4"
+)
+
+func main() {
+    e := echo.New()
+    e.GET("/", func(c echo.Context) error {
+        return c.String(http.StatusOK, "Hello, World from Echo!")
+    })
+    e.GET("/ping", func(c echo.Context) error {
+        return c.JSON(http.StatusOK, map[string]string{"message": "pong"})
+    })
+    e.Logger.Fatal(e.Start(":8083"))
+}`}
+                            </ExpandableCode>
+                        </div>
+                        <p className="text-sm text-base-content/70">注意：上述仅为最简示例。Gin 和 Echo 都拥有丰富的功能集，详细使用方法会是独立的、更广泛的主题。</p>
+                    </div>
+                </SecondaryCard>
+
+                <SecondaryCard title="构建 RESTful API">
+                    <div className="space-y-4">
+                        <div>
+                            <h4 className="font-semibold">REST 原则</h4>
+                            <p>REST (Representational State Transfer) 是一种用于设计网络应用的架构风格。核心原则包括：</p>
+                            <ul className="list-disc pl-5">
+                                <li><strong>客户端-服务器架构:</strong> 清晰分离关注点。</li>
+                                <li><strong>无状态 (Stateless):</strong> 每个来自客户端的请求都应包含所有必要信息，服务器不存储客户端状态。</li>
+                                <li><strong>可缓存 (Cacheable):</strong> 响应应该可以被标记为可缓存或不可缓存。</li>
+                                <li><strong>统一接口 (Uniform Interface):</strong> 使用标准 HTTP 方法 (GET, POST, PUT, DELETE, PATCH等)，通过 URI 标识资源。</li>
+                                <li><strong>分层系统 (Layered System):</strong> 客户端通常不知道它是否与最终服务器或中间层通信。</li>
+                            </ul>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold">JSON 处理</h4>
+                            <p>Go 的 <code>encoding/json</code> 包提供了对 JSON 的强大支持，包括序列化 (<code>json.Marshal</code>) 和反序列化 (<code>json.Unmarshal</code>)。</p>
+                            <ExpandableCode language="go" maxHeight={180}>
+{`package main
+
+import (
+    "encoding/json"
+    "fmt"
+    "net/http"
+)
+
+type User struct {
+    ID   int    \`json:"id"\` // struct tag 控制 JSON 字段名
+    Name string \`json:"name"\`
+    Age  int    \`json:"age"\`
+}
+
+func getUserHandler(w http.ResponseWriter, r *http.Request) {
+    user := User{ID: 1, Name: "Alice", Age: 30}
+    w.Header().Set("Content-Type", "application/json")
+    json.NewEncoder(w).Encode(user) // 直接将 struct 编码为 JSON 并写入 ResponseWriter
+}
+
+func createUserHandler(w http.ResponseWriter, r *http.Request) {
+    var user User
+    // 从请求体解码 JSON 到 user struct
+    err := json.NewDecoder(r.Body).Decode(&user)
+    if err != nil {
+        http.Error(w, err.Error(), http.StatusBadRequest)
+        return
+    }
+    fmt.Printf("Created user: %+v\\n", user)
+    w.WriteHeader(http.StatusCreated)
+    json.NewEncoder(w).Encode(user)
+}`}
+                            </ExpandableCode>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold">API 路由结构</h4>
+                            <p>设计清晰、一致的 API 路由结构非常重要。例如：</p>
+                            <ul className="list-disc pl-5">
+                                <li><code>GET /users</code> - 获取用户列表</li>
+                                <li><code>POST /users</code> - 创建新用户</li>
+                                <li><code>GET /users/{id}</code> - 获取特定 ID 的用户</li>
+                                <li><code>PUT /users/{id}</code> - 更新特定 ID 的用户</li>
+                                <li><code>DELETE /users/{id}</code> - 删除特定 ID 的用户</li>
+                            </ul>
+                        </div>
+                        <div>
+                            <h4 className="font-semibold">请求校验与 HTTP 状态码</h4>
+                            <p>对 API 输入进行校验至关重要。返回正确的 HTTP 状态码可以清晰地向客户端传达操作结果（如 <code>200 OK</code>, <code>201 Created</code>, <code>400 Bad Request</code>, <code>404 Not Found</code>, <code>500 Internal Server Error</code> 等）。</p>
+                        </div>
+                    </div>
+                </SecondaryCard>
+
+                <InfoCard title="模板与部署">
+                    <ul className="list-disc pl-5 space-y-2">
+                        <li><strong><code>html/template</code>:</strong> Go 标准库提供了 <code>html/template</code> 和 <code>text/template</code> 包用于服务器端渲染。<code>html/template</code> 更安全，能自动处理 HTML 转义，防止 XSS 攻击。</li>
+                        <li><strong>部署 Go Web 应用:</strong>
+                            <ul className="list-disc pl-5">
+                                <li><strong>构建二进制文件:</strong> Go 可以交叉编译为单个静态链接的二进制可执行文件，不依赖外部库，部署非常方便。只需将编译好的文件复制到服务器并运行即可。</li>
+                                <li><strong>Docker:</strong> 将 Go 应用打包到 Docker 容器中是现代部署的常用方法。可以创建一个非常小的 Docker 镜像，因为 Go 应用通常没有太多运行时依赖。</li>
+                                <li><strong>配置管理:</strong> 可以通过环境变量、配置文件（JSON, YAML, TOML）或配置服务来管理应用配置。</li>
+                                <li><strong>反向代理:</strong> 通常在 Go 应用前部署一个反向代理服务器（如 Nginx, Caddy）来处理 HTTPS、负载均衡、静态文件服务等。</li>
+                            </ul>
+                        </li>
+                    </ul>
+                </InfoCard>
+            </div>
+        </QuestionCard>
+    );
+}

--- a/src/components/knowledge/go/data/go_web_development.tsx
+++ b/src/components/knowledge/go/data/go_web_development.tsx
@@ -1,9 +1,8 @@
-import { QuestionCard } from "../../../../base/knowledge_question_card";
-import { InfoCard } from "../../../../card/info_card";
-import { WarningCard } from "../../../../card/warning_card";
-import { SuccessCard } from "../../../../card/success_card";
-import { SecondaryCard } from "../../../../card/secondary_card";
-import { ExpandableCode } from "../../../../base/expandable_code";
+import { QuestionCard } from "../../../base/knowledge_question_card";
+import { InfoCard } from "../../../card/info_card";
+import { SuccessCard } from "../../../card/success_card";
+import { SecondaryCard } from "../../../card/secondary_card";
+import { ExpandableCode } from "../../../base/expandable_code";
 
 interface Props {
     id: string;

--- a/src/components/knowledge/go/index.tsx
+++ b/src/components/knowledge/go/index.tsx
@@ -1,0 +1,1 @@
+// Placeholder for Go components export

--- a/src/route.tsx
+++ b/src/route.tsx
@@ -1,7 +1,13 @@
 import { createBrowserRouter } from "react-router";
 import BaseIndex from "./views/base_index";
 import { BaseJava } from "./views/knowledge/java/base_java";
+import { BaseGo } from "./views/knowledge/go/base_go";
 import { BaseKnowledge } from "./views/base_knowledge";
+import { GoBasicsPage } from "./views/knowledge/go/data/go_basics";
+import { GoConcurrencyPage } from "./views/knowledge/go/data/go_concurrency";
+import { GoWebDevelopmentPage } from "./views/knowledge/go/data/go_web_development";
+import { GoDatabasesPage } from "./views/knowledge/go/data/go_databases";
+import { GoTestingPage } from "./views/knowledge/go/data/go_testing";
 import { JavaBasics } from "./views/knowledge/java/data/java_basics";
 import { JavaSpringBoot } from "./views/knowledge/java/data/java_springboot";
 import { JavaRedis } from "./views/knowledge/java/data/java_redis";
@@ -92,15 +98,29 @@ export const router = createBrowserRouter([
             },
             {
                 path: "go",
-                Component: () => (
-                    <div className="flex items-center justify-center min-h-96">
-                        <div className="text-center">
-                            <i className="fi fi-rr-house-leave text-6xl text-accent mb-4"></i>
-                            <h3 className="text-2xl font-bold text-accent mb-2">Go 知识库</h3>
-                            <p className="text-base-content/70">Golang 基础、并发、微服务等内容正在准备中...</p>
-                        </div>
-                    </div>
-                )
+                Component: BaseGo,
+                children: [
+                    {
+                        path: "", // Default child route for /knowledge/go
+                        Component: GoBasicsPage
+                    },
+                    {
+                        path: "concurrency",
+                        Component: GoConcurrencyPage
+                    },
+                    {
+                        path: "web-development",
+                        Component: GoWebDevelopmentPage
+                    },
+                    {
+                        path: "databases",
+                        Component: GoDatabasesPage
+                    },
+                    {
+                        path: "testing",
+                        Component: GoTestingPage
+                    }
+                ]
             }
         ]
     }

--- a/src/views/knowledge/go/base_go.tsx
+++ b/src/views/knowledge/go/base_go.tsx
@@ -1,11 +1,6 @@
 import { Outlet } from "react-router";
 import { SideMenu } from "../../../components/base/knowledge_side_menu";
 import type { MenuItem } from "../../../components/base/knowledge_side_menu";
-import { GoBasicsPage } from "./data/go_basics";
-import { GoConcurrencyPage } from "./data/go_concurrency";
-import { GoWebDevelopmentPage } from "./data/go_web_development";
-import { GoDatabasesPage } from "./data/go_databases";
-import { GoTestingPage } from "./data/go_testing";
 
 // Go 知识点菜单
 const goMenuItems: MenuItem[] = [

--- a/src/views/knowledge/go/base_go.tsx
+++ b/src/views/knowledge/go/base_go.tsx
@@ -1,0 +1,73 @@
+import { Outlet } from "react-router";
+import { SideMenu } from "../../../components/base/knowledge_side_menu";
+import type { MenuItem } from "../../../components/base/knowledge_side_menu";
+import { GoBasicsPage } from "./data/go_basics";
+import { GoConcurrencyPage } from "./data/go_concurrency";
+import { GoWebDevelopmentPage } from "./data/go_web_development";
+import { GoDatabasesPage } from "./data/go_databases";
+import { GoTestingPage } from "./data/go_testing";
+
+// Go 知识点菜单
+const goMenuItems: MenuItem[] = [
+    {
+        id: "go-basics",
+        label: "Go 基础",
+        path: "/knowledge/go", // Default path for the Go section
+        icon: "fi fi-rr-document", // Example icon
+        description: "Go 语言的核心语法和基础概念"
+    },
+    {
+        id: "go-concurrency",
+        label: "Goroutines 与 Channels",
+        path: "/knowledge/go/concurrency",
+        icon: "fi fi-rr-shuffle",
+        description: "Go 语言并发核心：Goroutines 和 Channels"
+    },
+    {
+        id: "go-web-development",
+        label: "Web 开发",
+        path: "/knowledge/go/web-development",
+        icon: "fi fi-rr-globe",
+        description: "使用 Go 进行 Web 应用和 API 开发"
+    },
+    {
+        id: "go-databases",
+        label: "操作数据库",
+        path: "/knowledge/go/databases",
+        icon: "fi fi-rr-database",
+        description: "使用 Go 连接和操作各类数据库"
+    },
+    {
+        id: "go-testing",
+        label: "测试",
+        path: "/knowledge/go/testing",
+        icon: "fi fi-rr-test-tube",
+        description: "Go 语言中的单元测试和基准测试"
+    }
+];
+
+export function BaseGo() {
+    document.title = "Go技术栈 - 筱锋的知识库";
+
+    return (
+        <div className="flex h-full">
+            {/* 左侧菜单 - 固定不随滚动 */}
+            <div className="sticky top-0 h-full">
+                <SideMenu
+                    title="Go 技术栈"
+                    icon="fi fi-brands-golang"
+                    menuItems={goMenuItems}
+                />
+            </div>
+
+            {/* 右侧内容 - 可滚动区域 */}
+            <div className="flex-1 overflow-y-auto bg-gradient-to-br from-base-100 via-base-200/30 to-base-200/60">
+                <div className="p-8 mx-auto max-w-6xl">
+                    <div className="bg-base-100 rounded-2xl shadow-xl p-6 backdrop-blur-sm border border-base-300/20">
+                        <Outlet />
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/views/knowledge/go/data/go_basics.tsx
+++ b/src/views/knowledge/go/data/go_basics.tsx
@@ -1,0 +1,5 @@
+import { GoBasics } from "../../../../components/knowledge/go/data/go_basics";
+
+export function GoBasicsPage() {
+    return <GoBasics id="go-basics" />;
+}

--- a/src/views/knowledge/go/data/go_concurrency.tsx
+++ b/src/views/knowledge/go/data/go_concurrency.tsx
@@ -1,0 +1,5 @@
+import { GoConcurrency } from "../../../../components/knowledge/go/data/go_concurrency";
+
+export function GoConcurrencyPage() {
+    return <GoConcurrency id="go-concurrency" />;
+}

--- a/src/views/knowledge/go/data/go_databases.tsx
+++ b/src/views/knowledge/go/data/go_databases.tsx
@@ -1,0 +1,5 @@
+import { GoDatabases } from "../../../../components/knowledge/go/data/go_databases";
+
+export function GoDatabasesPage() {
+    return <GoDatabases id="go-databases" />;
+}

--- a/src/views/knowledge/go/data/go_testing.tsx
+++ b/src/views/knowledge/go/data/go_testing.tsx
@@ -1,0 +1,5 @@
+import { GoTesting } from "../../../../components/knowledge/go/data/go_testing";
+
+export function GoTestingPage() {
+    return <GoTesting id="go-testing" />;
+}

--- a/src/views/knowledge/go/data/go_web_development.tsx
+++ b/src/views/knowledge/go/data/go_web_development.tsx
@@ -1,0 +1,5 @@
+import { GoWebDevelopment } from "../../../../components/knowledge/go/data/go_web_development";
+
+export function GoWebDevelopmentPage() {
+    return <GoWebDevelopment id="go-web-development" />;
+}

--- a/src/views/knowledge/go/index.tsx
+++ b/src/views/knowledge/go/index.tsx
@@ -1,0 +1,2 @@
+// Placeholder for Go views export
+export * from './base_go';


### PR DESCRIPTION
Adds a new knowledge base section for the Go programming language, including articles on:
- Go Basics (syntax, data types, control flow)
- Goroutines and Channels (concurrency)
- Go Web Development (net/http, Gin/Echo)
- Working with Databases in Go (database/sql, GORM)
- Testing in Go (unit and benchmark tests)

This commit also fills in placeholder content for existing CSS articles:
- CSS Flexbox
- CSS Grid
- CSS Layout Basics (box model, positioning, floats)
- CSS Responsive Design (media queries, fluid layouts)

All new content is in Chinese and follows the established component structure for the knowledge base. Includes necessary routing and side menu updates for the Go section.